### PR TITLE
chore: Remove duplicated notification subtest: 'should get an error,wrong credential id'

### DIFF
--- a/internal/core/services/tests/notification_test.go
+++ b/internal/core/services/tests/notification_test.go
@@ -87,11 +87,4 @@ func TestNotification_SendNotification(t *testing.T) {
 		require.NoError(t, err)
 		assert.Error(t, notificationService.SendCreateCredentialNotification(ctx, message))
 	})
-
-	t.Run("should get an error,wrong credential id", func(t *testing.T) {
-		ev := event.CreateCredential{CredentialIDs: []string{"wrong id"}, IssuerID: did.String()}
-		message, err := ev.Marshal()
-		require.NoError(t, err)
-		assert.Error(t, notificationService.SendCreateCredentialNotification(ctx, message))
-	})
 }


### PR DESCRIPTION
Noticed this duplicated subtest while exploring the codebase.