### PR TITLE
feat: enabling RHS in the api and  api-admin

### DIFF
--- a/cmd/platform/main.go
+++ b/cmd/platform/main.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-chi/chi/v5"
@@ -109,7 +108,7 @@ func main() {
 	if cfg.ReverseHashService.Enabled {
 		rhsp = reverse_hash.NewRhsPublisher(&proof.HTTPReverseHashCli{
 			URL:         cfg.ReverseHashService.URL,
-			HTTPTimeout: time.Second * reverse_hash.DefaultRHSTimeOut,
+			HTTPTimeout: reverse_hash.DefaultRHSTimeOut,
 		}, true)
 	}
 

--- a/cmd/platform/main.go
+++ b/cmd/platform/main.go
@@ -7,12 +7,14 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-chi/chi/v5"
 	chiMiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
 	redis2 "github.com/go-redis/redis/v8"
+	proof "github.com/iden3/merkletree-proof"
 
 	"github.com/polygonid/sh-id-platform/internal/api"
 	"github.com/polygonid/sh-id-platform/internal/config"
@@ -104,6 +106,12 @@ func main() {
 	circuitsLoaderService := loaders.NewCircuits(cfg.Circuit.Path)
 
 	rhsp := reverse_hash.NewRhsPublisher(nil, false)
+	if cfg.ReverseHashService.Enabled {
+		rhsp = reverse_hash.NewRhsPublisher(&proof.HTTPReverseHashCli{
+			URL:         cfg.ReverseHashService.URL,
+			HTTPTimeout: time.Second * reverse_hash.DefaultRHSTimeOut,
+		}, true)
+	}
 
 	// repositories initialization
 	identityRepository := repositories.NewIdentity()

--- a/cmd/platform_ui/main.go
+++ b/cmd/platform_ui/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-chi/chi/v5"
@@ -131,7 +130,7 @@ func main() {
 	if cfg.ReverseHashService.Enabled {
 		rhsp = reverse_hash.NewRhsPublisher(&proof.HTTPReverseHashCli{
 			URL:         cfg.ReverseHashService.URL,
-			HTTPTimeout: time.Second * reverse_hash.DefaultRHSTimeOut,
+			HTTPTimeout: reverse_hash.DefaultRHSTimeOut,
 		}, true)
 	}
 

--- a/cmd/platform_ui/main.go
+++ b/cmd/platform_ui/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-chi/chi/v5"
@@ -19,6 +20,7 @@ import (
 	"github.com/iden3/go-iden3-auth/pubsignals"
 	"github.com/iden3/go-iden3-auth/state"
 	core "github.com/iden3/go-iden3-core"
+	proof "github.com/iden3/merkletree-proof"
 
 	"github.com/polygonid/sh-id-platform/internal/api_ui"
 	"github.com/polygonid/sh-id-platform/internal/config"
@@ -126,6 +128,12 @@ func main() {
 	circuitsLoaderService := loaders.NewCircuits(cfg.Circuit.Path)
 
 	rhsp := reverse_hash.NewRhsPublisher(nil, false)
+	if cfg.ReverseHashService.Enabled {
+		rhsp = reverse_hash.NewRhsPublisher(&proof.HTTPReverseHashCli{
+			URL:         cfg.ReverseHashService.URL,
+			HTTPTimeout: time.Second * reverse_hash.DefaultRHSTimeOut,
+		}, true)
+	}
 
 	// repositories initialization
 	identityRepository := repositories.NewIdentity()

--- a/internal/core/services/claims.go
+++ b/internal/core/services/claims.go
@@ -612,8 +612,8 @@ func (c *claim) newVerifiableCredential(claimReq *ports.CreateClaimRequest, vcID
 
 func (c *claim) getRevocationSource(issuerDID string, nonce uint64, singleIssuer bool) interface{} {
 	if c.cfg.RHSEnabled {
-		return &verifiable.RHSCredentialStatus{
-			ID:              fmt.Sprintf("%s/node", strings.TrimSuffix(c.cfg.RHSUrl, "/")),
+		return &verifiable.CredentialStatus{
+			ID:              strings.TrimSuffix(c.cfg.RHSUrl, "/"),
 			Type:            verifiable.Iden3ReverseSparseMerkleTreeProof,
 			RevocationNonce: nonce,
 			StatusIssuer: &verifiable.CredentialStatus{

--- a/internal/core/services/revocation.go
+++ b/internal/core/services/revocation.go
@@ -132,7 +132,7 @@ func getRevocationProofFromIssuer(ctx context.Context, url string) (*verifiable.
 
 func getNonRevocationProofFromRHS(ctx context.Context, rhsURL string, data, issuerRoot *merkletree.Hash) (*verifiable.RevocationStatus, error) {
 	rhsCli := proof.HTTPReverseHashCli{
-		URL:         strings.TrimSuffix(rhsURL, "/node"),
+		URL:         rhsURL,
 		HTTPTimeout: time.Second * defaultRevocationTime,
 	}
 

--- a/pkg/reverse_hash/reverse_hash.go
+++ b/pkg/reverse_hash/reverse_hash.go
@@ -11,6 +11,9 @@ import (
 	"github.com/polygonid/sh-id-platform/internal/log"
 )
 
+// DefaultRHSTimeOut - default timeout for reverse hash service requests.
+const DefaultRHSTimeOut = 30
+
 // stateHashes - handle hashes states.
 type stateHashes struct {
 	State  merkletree.Hash
@@ -43,11 +46,10 @@ func NewRhsPublisher(rhsCli *proof.HTTPReverseHashCli, ignoreRHSErrors bool) *rh
 //   - if claim's tree root is changed, also send new claim's tree root with
 //     its parents up to RoR tree root.
 func (rhsp *rhsPublisher) PushHashesToRHS(ctx context.Context, newState, prevState *domain.IdentityState, revocations []*domain.Revocation, trees *domain.IdentityMerkleTrees) error {
-	// TODO - check rhs cli
 	// if Reverse-Hash-Service is not configure, do nothing.
-	//if i.rhsCli == nil {
-	//	return nil
-	//}
+	if rhsp.rhsCli == nil {
+		return nil
+	}
 
 	nb := newNodesBuilder()
 
@@ -88,10 +90,8 @@ func (rhsp *rhsPublisher) PushHashesToRHS(ctx context.Context, newState, prevSta
 	}
 
 	if nb.numberOfNodes() > 0 {
-		// todo: call rhs
-		// err = i.rhsCli.SaveNodes(ctx, nb.nodes)
 		log.Info(ctx, "new state nodes", nb.nodes)
-		err = nil
+		err = rhsp.rhsCli.SaveNodes(ctx, nb.nodes)
 	}
 	return err
 }

--- a/pkg/reverse_hash/reverse_hash.go
+++ b/pkg/reverse_hash/reverse_hash.go
@@ -3,6 +3,7 @@ package reverse_hash
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/iden3/go-merkletree-sql/v2"
 	proof "github.com/iden3/merkletree-proof"
@@ -12,7 +13,7 @@ import (
 )
 
 // DefaultRHSTimeOut - default timeout for reverse hash service requests.
-const DefaultRHSTimeOut = 30
+const DefaultRHSTimeOut = 30 * time.Second
 
 // stateHashes - handle hashes states.
 type stateHashes struct {


### PR DESCRIPTION
In order to enable the RHS:
1. Enable it in the .env-issuer -> ISSUER_REVERSE_HASH_SERVICE_ENABLED=true
2. Install the RHS -> https://github.com/iden3/reverse-hash-service
3. ISSUER_REVERSE_HASH_SERVICE_URL= {RHS url}