### PR TITLE
Fix issuer UI restart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,20 +201,14 @@ add-host-url-swagger:
 
 .PHONY: rm-issuer-imgs
 rm-issuer-imgs: stop
-	docker rmi -f issuer-api issuer-ui issuer-api-ui issuer-pending_publisher|| true
+	$(DOCKER_COMPOSE_CMD) rm -f
+	docker rmi -f issuer-api issuer-ui issuer-api-ui issuer-pending_publisher
 
 .PHONY: restart-ui
 restart-ui: rm-issuer-imgs up run run-ui
 
 .PHONY: restart-ui-arm
 restart-ui-arm: rm-issuer-imgs up run-arm run-ui-arm
-
-
-## usage: make new_password=xxx change-vault-password
-#.PHONY: change-vault-password
-#change-vault-password:
-#	docker exec issuer-vault-1 \
-#	vault write auth/userpass/users/issuernode password=$(new_password)
 
 .PHONY: print-did
 print-did:

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ These steps can be followed to get up and running with all features as quickly a
 1. Run `make up`. This launches 3 containers with Postgres, Redis and Vault. Ignore the warnings about variables, since those are set up in the next step.
 1. **If you are on an Apple Silicon chip (e.g. M1/M2), run `make run-arm`**. Otherwise, run `make run`. This starts up the issuer API, whose frontend can be accessed via the browser (default <http://localhost:3001>).
 1. [Add](#import-wallet-private-key-to-vault) your Ethereum private key to the Vault.
-1. [Add](#add-vault-to-configuration-file) the Vault to the config.
-1. [Create](#create-issuer-did) your issuer DID.
-1. _(Optional)_ To run the UI with its own API, first copy `.env-ui.sample` as `.env-ui`. Please see the [configuration](#development-ui) section for more details.
-1. _(Optional)_ Run `make run-ui` (or `make run-ui-arm` on Apple Silicon) to have the Web UI available on <http://localhost:8088> (in production mode). Its HTTP auth credentials are set in `.env-ui`. The UI API also has a frontend for API documentation (default <http://localhost:3002>).
+2. [Setup vault](#setup-vault).
+3. [Create](#create-issuer-did) your issuer DID.
+4. _(Optional)_ To run the UI with its own API, first copy `.env-ui.sample` as `.env-ui`. Please see the [configuration](#development-ui) section for more details.
+5. _(Optional)_ Run `make run-ui` (or `make run-ui-arm` on Apple Silicon) to have the Web UI available on <http://localhost:8088> (in production mode). Its HTTP auth credentials are set in `.env-ui`. The UI API also has a frontend for API documentation (default <http://localhost:3002>).
 
 #### Docker Guide Requirements
 
@@ -169,7 +169,7 @@ make private_key=<YOUR_WALLET_PRIVATE_KEY> add-private-key;
 #   Success! Data written to: iden3/import/pbkey
 ```
 
-#### ~~Add Vault To Configuration File~~ Setup Vault
+#### Setup Vault
 
 ##### Option 1: Using root vault token (not recommended :thumbsdown:)
 This will get the vault token from the Hashicorp vault docker instance and add it to our `./env-issuer` file.
@@ -434,10 +434,10 @@ Make sure you have Postgres, Redis and Vault properly installed & configured. Do
 1. Run `./bin/platform` command to start the issuer.
 1. Run `./bin/pending_publisher`. This checks that publishing transactions to the blockchain works.
 1. [Add](#import-wallet-private-key-to-vault) your Ethereum private key to the Vault.
-1. [Add](#add-vault-to-configuration-file) the Vault to the config.
-1. [Create](#create-issuer-did) your issuer DID.
-1. _(Optional)_ To set up the UI with its own API, first copy `.env-ui.sample` as `.env-ui`. Please see the [configuration](#configuration) section for more details.
-1. _Documentation pending: standalone UI setup._
+2. [Setup vault](#setup-vault).
+3. [Create](#create-issuer-did) your issuer DID.
+4. _(Optional)_ To set up the UI with its own API, first copy `.env-ui.sample` as `.env-ui`. Please see the [configuration](#configuration) section for more details.
+5. _Documentation pending: standalone UI setup._
 
 ---
 

--- a/ui/scripts/deploy.sh
+++ b/ui/scripts/deploy.sh
@@ -30,8 +30,8 @@ cat /etc/nginx/.htpasswd
 # Copy app dist
 cp -r /app/dist/. /usr/share/nginx/html
 
-# Delete source code
-rm -rf /app
+# Delete build files
+rm -rf /app/dist
 
 # Run nginx
 nginx -g 'daemon off;'


### PR DESCRIPTION
This PR fixes:

 * A bug that prevented the service `issuer-ui` from starting after it was stopped.
 * A broken link in the readme.