### PR TITLE
chore: avoid fetching credentials with empty mtp proofs

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -398,6 +398,8 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+        '409':
+          $ref: '#/components/responses/409'
         '500':
           $ref: '#/components/responses/500'
 #agent
@@ -929,6 +931,12 @@ components:
             $ref: '#/components/schemas/GenericErrorMessage'
     '404':
       description: 'Not found'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GenericErrorMessage'
+    '409':
+      description: 'Conflict'
       content:
         application/json:
           schema:

--- a/api_ui/api.yaml
+++ b/api_ui/api.yaml
@@ -504,6 +504,8 @@ paths:
           $ref: '#/components/responses/400'
         '404':
           $ref: '#/components/responses/404'
+        '409':
+          $ref: '#/components/responses/409'
         '500':
           $ref: '#/components/responses/500'
 
@@ -1833,6 +1835,12 @@ components:
             $ref: '#/components/schemas/GenericErrorMessage'
     '404':
       description: 'Entity not found'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GenericErrorMessage'
+    '409':
+      description: 'Conflict'
       content:
         application/json:
           schema:

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -229,6 +229,9 @@ type N403 = GenericErrorMessage
 // N404 defines model for 404.
 type N404 = GenericErrorMessage
 
+// N409 defines model for 409.
+type N409 = GenericErrorMessage
+
 // N422 defines model for 422.
 type N422 = GenericErrorMessage
 
@@ -1140,6 +1143,8 @@ type N403JSONResponse GenericErrorMessage
 
 type N404JSONResponse GenericErrorMessage
 
+type N409JSONResponse GenericErrorMessage
+
 type N422JSONResponse GenericErrorMessage
 
 type N500JSONResponse GenericErrorMessage
@@ -1730,6 +1735,15 @@ type GetClaimQrCode404JSONResponse struct{ N404JSONResponse }
 func (response GetClaimQrCode404JSONResponse) VisitGetClaimQrCodeResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetClaimQrCode409JSONResponse struct{ N409JSONResponse }
+
+func (response GetClaimQrCode409JSONResponse) VisitGetClaimQrCodeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(409)
 
 	return json.NewEncoder(w).Encode(response)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -369,6 +369,11 @@ func (s *Server) GetClaimQrCode(ctx context.Context, request GetClaimQrCodeReque
 		}
 		return GetClaimQrCode500JSONResponse{N500JSONResponse{err.Error()}}, nil
 	}
+
+	if !claim.ValidProof() {
+		return GetClaimQrCode409JSONResponse{N409JSONResponse{"State must be published before fetching MTP type credential"}}, nil
+	}
+
 	return toGetClaimQrCode200JSONResponse(claim, s.cfg.ServerUrl), nil
 }
 

--- a/internal/api_ui/api.gen.go
+++ b/internal/api_ui/api.gen.go
@@ -388,6 +388,9 @@ type N401 = GenericErrorMessage
 // N404 defines model for 404.
 type N404 = GenericErrorMessage
 
+// N409 defines model for 409.
+type N409 = GenericErrorMessage
+
 // N422 defines model for 422.
 type N422 = GenericErrorMessage
 
@@ -2188,6 +2191,8 @@ type N401JSONResponse GenericErrorMessage
 
 type N404JSONResponse GenericErrorMessage
 
+type N409JSONResponse GenericErrorMessage
+
 type N422JSONResponse GenericErrorMessage
 
 type N500JSONResponse GenericErrorMessage
@@ -3200,6 +3205,15 @@ type GetCredentialQrCode404JSONResponse struct{ N404JSONResponse }
 func (response GetCredentialQrCode404JSONResponse) VisitGetCredentialQrCodeResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetCredentialQrCode409JSONResponse struct{ N409JSONResponse }
+
+func (response GetCredentialQrCode409JSONResponse) VisitGetCredentialQrCodeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(409)
 
 	return json.NewEncoder(w).Encode(response)
 }

--- a/internal/api_ui/server.go
+++ b/internal/api_ui/server.go
@@ -617,6 +617,9 @@ func (s *Server) GetCredentialQrCode(ctx context.Context, req GetCredentialQrCod
 		if errors.Is(err, services.ErrClaimNotFound) {
 			return GetCredentialQrCode400JSONResponse{N400JSONResponse{"Credential not found"}}, nil
 		}
+		if errors.Is(err, services.ErrEmptyMTPProof) {
+			return GetCredentialQrCode409JSONResponse{N409JSONResponse{"State must be published before fetching MTP type credentials"}}, nil
+		}
 		return GetCredentialQrCode500JSONResponse{N500JSONResponse{err.Error()}}, nil
 	}
 	qrContent := resp.QrCodeURL

--- a/internal/api_ui/server_test.go
+++ b/internal/api_ui/server_test.go
@@ -2128,7 +2128,9 @@ func TestServer_GetCredentialQrCode(t *testing.T) {
 	typeC := "KYCAgeCredential"
 	merklizedRootPosition := "index"
 	schema := "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json/KYCAgeCredential-v3.json"
-	createdClaim, err := claimsService.Save(ctx, ports.NewCreateClaimRequest(did, schema, credentialSubject, nil, typeC, nil, nil, &merklizedRootPosition, common.ToPointer(true), common.ToPointer(true), nil, false, verifiable.SparseMerkleTreeProof, nil, nil))
+	createdSIGClaim, err := claimsService.Save(ctx, ports.NewCreateClaimRequest(did, schema, credentialSubject, nil, typeC, nil, nil, &merklizedRootPosition, common.ToPointer(true), common.ToPointer(false), nil, false, verifiable.SparseMerkleTreeProof, nil, nil))
+	require.NoError(t, err)
+	createdMTPClaim, err := claimsService.Save(ctx, ports.NewCreateClaimRequest(did, schema, credentialSubject, nil, typeC, nil, nil, &merklizedRootPosition, common.ToPointer(false), common.ToPointer(true), nil, false, verifiable.SparseMerkleTreeProof, nil, nil))
 	require.NoError(t, err)
 
 	type expected struct {
@@ -2154,9 +2156,19 @@ func TestServer_GetCredentialQrCode(t *testing.T) {
 			},
 		},
 		{
+			name: "no mtp proof",
+			request: GetCredentialQrCodeRequestObject{
+				Id: createdMTPClaim.ID,
+			},
+			expected: expected{
+				message:  common.ToPointer("State must be published before fetching MTP type credentials"),
+				httpCode: http.StatusConflict,
+			},
+		},
+		{
 			name: "happy path",
 			request: GetCredentialQrCodeRequestObject{
-				Id: createdClaim.ID,
+				Id: createdSIGClaim.ID,
 			},
 			expected: expected{
 				httpCode:   http.StatusOK,
@@ -2166,7 +2178,7 @@ func TestServer_GetCredentialQrCode(t *testing.T) {
 		{
 			name: "happy path with qr code of type link",
 			request: GetCredentialQrCodeRequestObject{
-				Id: createdClaim.ID,
+				Id: createdSIGClaim.ID,
 				Params: GetCredentialQrCodeParams{
 					Type: common.ToPointer(GetCredentialQrCodeParamsTypeLink),
 				},
@@ -2179,7 +2191,7 @@ func TestServer_GetCredentialQrCode(t *testing.T) {
 		{
 			name: "happy path with qr code of type raw",
 			request: GetCredentialQrCodeRequestObject{
-				Id: createdClaim.ID,
+				Id: createdSIGClaim.ID,
 				Params: GetCredentialQrCodeParams{
 					Type: common.ToPointer(GetCredentialQrCodeParamsTypeRaw),
 				},

--- a/internal/core/domain/claim.go
+++ b/internal/core/domain/claim.go
@@ -125,6 +125,15 @@ func (c *CoreClaim) Get() *core.Claim {
 	return (*core.Claim)(c)
 }
 
+// ValidProof returns true if the claim has a valid proof
+func (c *Claim) ValidProof() bool {
+	if !c.MtProof || c.SignatureProof.Status != pgtype.Null { // this second condition is for credentials that has both types of proofs
+		return true
+	}
+
+	return c.MTPProof.Status != pgtype.Null
+}
+
 // BuildTreeState returns circuits.TreeState structure
 func BuildTreeState(state, claimsTreeRoot, revocationTreeRoot, rootOfRoots *string) (circuits.TreeState, error) {
 	return circuits.TreeState{

--- a/internal/core/services/claims.go
+++ b/internal/core/services/claims.go
@@ -49,6 +49,7 @@ var (
 	ErrInvalidCredentialSubject          = errors.New("credential subject does not match the provided schema")         // ErrInvalidCredentialSubject means the credentialSubject does not match the schema provided
 	ErrUnsupportedRefreshServiceType     = errors.New("unsupported refresh service type")                              // ErrUnsupportedRefreshServiceType means the refresh service type is not supported
 	ErrRefreshServiceLacksExpirationTime = errors.New("credential request with refresh service lacks expiration time") // ErrRefreshServiceLacksExpirationTime means the credential request includes a refresh service, but the expiration time is not set
+	ErrEmptyMTPProof                     = errors.New("mtp credentials must have a mtp proof to be fetched")           // ErrEmptyMTPProof means that a credential of MTP type can not be fetched if it does not contain the proof
 )
 
 type claim struct {
@@ -320,6 +321,10 @@ func (c *claim) GetCredentialQrCode(ctx context.Context, issID *w3c.DID, id uuid
 	claim, err := c.GetByID(ctx, issID, id)
 	if err != nil {
 		return nil, err
+	}
+
+	if !claim.ValidProof() {
+		return nil, ErrEmptyMTPProof
 	}
 	credID := uuid.New()
 	qrCode := protocol.CredentialsOfferMessage{


### PR DESCRIPTION
avoid fetching credential QR Codes for empty mtp proofs credentials. 

Returns a 409 conflict when the proof is empty (suggest a code)