### PR TITLE
fix: could not create links with new type property in credential status

### DIFF
--- a/internal/jsonschema/schema.go
+++ b/internal/jsonschema/schema.go
@@ -202,7 +202,8 @@ func createDummyVC(cSubject map[string]interface{}, schemaType string, schemaCon
 			"type": "JsonSchemaValidator2018",
 		},
 		"credentialStatus": map[string]interface{}{
-			"id": "testStatus",
+			"id":   "testStatus",
+			"type": "someType",
 		},
 		"credentialSubject": cSubject,
 		"id":                "https://someURL/someschemaContext.jsonld",


### PR DESCRIPTION
As part of the link creation we validate that a VC can be produced with the provided schema and credential Subject. New Schemas include a new type property inside the credential Status that has to be added to the dummy VC