### PR TITLE
fix: avoid sending null scope

### DIFF
--- a/internal/api_ui/server_test.go
+++ b/internal/api_ui/server_test.go
@@ -260,7 +260,7 @@ func TestServer_AuthQRCode(t *testing.T) {
 					Body: protocol.AuthorizationRequestMessageBody{
 						CallbackURL: "https://testing.env/v1/authentication/callback?sessionID=",
 						Reason:      "authentication",
-						Scope:       nil,
+						Scope:       make([]protocol.ZeroKnowledgeProofRequest, 0),
 					},
 					From: issuerDID.String(),
 					Typ:  "application/iden3comm-plain-json",
@@ -278,7 +278,7 @@ func TestServer_AuthQRCode(t *testing.T) {
 					Body: protocol.AuthorizationRequestMessageBody{
 						CallbackURL: "https://testing.env/v1/authentication/callback?sessionID=",
 						Reason:      "authentication",
-						Scope:       nil,
+						Scope:       make([]protocol.ZeroKnowledgeProofRequest, 0),
 					},
 					From: issuerDID.String(),
 					Typ:  "application/iden3comm-plain-json",
@@ -296,7 +296,7 @@ func TestServer_AuthQRCode(t *testing.T) {
 					Body: protocol.AuthorizationRequestMessageBody{
 						CallbackURL: "https://testing.env/v1/authentication/callback?sessionID=",
 						Reason:      "authentication",
-						Scope:       nil,
+						Scope:       make([]protocol.ZeroKnowledgeProofRequest, 0),
 					},
 					From: issuerDID.String(),
 					Typ:  "application/iden3comm-plain-json",

--- a/internal/core/services/identity.go
+++ b/internal/core/services/identity.go
@@ -482,6 +482,7 @@ func (i *identity) CreateAuthenticationQRCode(ctx context.Context, serverURL str
 		Body: protocol.AuthorizationRequestMessageBody{
 			CallbackURL: fmt.Sprintf("%s/v1/authentication/callback?sessionID=%s", serverURL, sessionID),
 			Reason:      authReason,
+			Scope:       make([]protocol.ZeroKnowledgeProofRequest, 0),
 		},
 	}
 	if err := i.sessionManager.Set(ctx, sessionID.String(), *qrCode); err != nil {

--- a/internal/core/services/link.go
+++ b/internal/core/services/link.go
@@ -182,6 +182,7 @@ func (ls *Link) CreateQRCode(ctx context.Context, issuerDID w3c.DID, linkID uuid
 		Body: protocol.AuthorizationRequestMessageBody{
 			CallbackURL: fmt.Sprintf("%s/v1/credentials/links/callback?sessionID=%s&linkID=%s", serverURL, sessionID, linkID.String()),
 			Reason:      authReason,
+			Scope:       make([]protocol.ZeroKnowledgeProofRequest, 0),
 		},
 	}
 


### PR DESCRIPTION
avoid sending null scope in qr codes