### PR TITLE
add separate error variable for setLink()

### DIFF
--- a/internal/core/services/link.go
+++ b/internal/core/services/link.go
@@ -233,10 +233,10 @@ func (ls *Link) IssueClaim(ctx context.Context, sessionID string, issuerDID w3c.
 	}
 
 	if err := ls.validate(ctx, link); err != nil {
-		err := ls.sessionManager.SetLink(ctx, linkState.CredentialStateCacheKey(linkID.String(), sessionID), *linkState.NewStateError(err))
-		if err != nil {
-			log.Error(ctx, "cannot set the sate", "err", err)
-			return err
+		setLinkError := ls.sessionManager.SetLink(ctx, linkState.CredentialStateCacheKey(linkID.String(), sessionID), *linkState.NewStateError(err))
+		if setLinkError != nil {
+			log.Error(ctx, "cannot set the sate", "err", setLinkError)
+			return setLinkError
 		}
 
 		return err

--- a/internal/core/services/link.go
+++ b/internal/core/services/link.go
@@ -235,7 +235,7 @@ func (ls *Link) IssueClaim(ctx context.Context, sessionID string, issuerDID w3c.
 	if err := ls.validate(ctx, link); err != nil {
 		setLinkError := ls.sessionManager.SetLink(ctx, linkState.CredentialStateCacheKey(linkID.String(), sessionID), *linkState.NewStateError(err))
 		if setLinkError != nil {
-			log.Error(ctx, "cannot set the sate", "err", setLinkError)
+			log.Error(ctx, "cannot set the state", "err", setLinkError)
 			return setLinkError
 		}
 


### PR DESCRIPTION
If only one error is used, when the first value of "err" is not nil and second value of "err" is nil, there may be a situation that "the function execution should marked as failed, but it returns nil"