### PR TITLE
feat: fuzzy query all the content in the value of credentialSubject

### DIFF
--- a/internal/api_ui/api.gen.go
+++ b/internal/api_ui/api.gen.go
@@ -137,15 +137,15 @@ type CreateCredentialRequest struct {
 
 // CreateLinkRequest defines model for CreateLinkRequest.
 type CreateLinkRequest struct {
-	CredentialExpiration *time.Time 		 `json:"credentialExpiration,omitempty"`
-	CredentialSubject    CredentialSubject   `json:"credentialSubject"`
-	DisplayMethod        *DisplayMethod      `json:"displayMethod,omitempty"`
-	Expiration           *time.Time          `json:"expiration,omitempty"`
-	LimitedClaims        *int                `json:"limitedClaims"`
-	MtProof              bool                `json:"mtProof"`
-	RefreshService       *RefreshService     `json:"refreshService,omitempty"`
-	SchemaID             uuid.UUID           `json:"schemaID"`
-	SignatureProof       bool                `json:"signatureProof"`
+	CredentialExpiration *time.Time        `json:"credentialExpiration,omitempty"`
+	CredentialSubject    CredentialSubject `json:"credentialSubject"`
+	DisplayMethod        *DisplayMethod    `json:"displayMethod,omitempty"`
+	Expiration           *time.Time        `json:"expiration,omitempty"`
+	LimitedClaims        *int              `json:"limitedClaims"`
+	MtProof              bool              `json:"mtProof"`
+	RefreshService       *RefreshService   `json:"refreshService,omitempty"`
+	SchemaID             uuid.UUID         `json:"schemaID"`
+	SignatureProof       bool              `json:"signatureProof"`
 }
 
 // Credential defines model for Credential.
@@ -480,6 +480,9 @@ type GetCredentialsParams struct {
 
 	// Query Query string to do full text search
 	Query *string `form:"query,omitempty" json:"query,omitempty"`
+
+	// VCFuzzyQuery fuzzy query all the content in the value of credentialSubject
+	VCFuzzyQuery *string `form:"query,omitempty" json:"query,omitempty"`
 
 	// Page Page to fetch. First is one. If omitted, all results will be returned.
 	Page *uint `form:"page,omitempty" json:"page,omitempty"`

--- a/internal/api_ui/server.go
+++ b/internal/api_ui/server.go
@@ -802,6 +802,9 @@ func getCredentialsFilter(ctx context.Context, req GetCredentialsRequestObject) 
 	if req.Params.Query != nil {
 		filter.FTSQuery = *req.Params.Query
 	}
+	if req.Params.VCFuzzyQuery != nil {
+		filter.VCFuzzyQuery = *req.Params.VCFuzzyQuery
+	}
 
 	filter.MaxResults = 50
 	if req.Params.MaxResults != nil {

--- a/internal/core/ports/claims_service.go
+++ b/internal/core/ports/claims_service.go
@@ -70,6 +70,7 @@ type ClaimsFilter struct {
 	Subject         string
 	QueryField      string
 	QueryFieldValue string
+	VCFuzzyQuery    string
 	FTSQuery        string
 	FTSAndCond      bool
 	Proofs          []verifiable.ProofType

--- a/internal/repositories/claims.go
+++ b/internal/repositories/claims.go
@@ -827,6 +827,15 @@ func buildGetAllQueryAndFilters(issuerID w3c.DID, filter *ports.ClaimsFilter) (q
 		filters = append(filters, filter.QueryField, filter.QueryFieldValue)
 		query = fmt.Sprintf("%s and data -> 'credentialSubject'  ->>$%d = $%d ", query, len(filters)-1, len(filters))
 	}
+	/*
+		/	Used to fuzzy query all the content in the value of credentialSubject, case-insensitive
+	*/
+	if filter.VCFuzzyQuery != "" {
+		filters = append(filters, "%%%s%%", filter.VCFuzzyQuery)
+		query = fmt.Sprintf("%s AND EXISTS "+
+			"(SELECT 1 FROM jsonb_each_text(data->'credentialSubject') AS map(key, value) "+
+			"WHERE value ILIKE $%d", query, len(filters))
+	}
 	if filter.ExpiredOn != nil {
 		t := *filter.ExpiredOn
 		filters = append(filters, t.Unix())


### PR DESCRIPTION
- Used to fuzzy query all the content in the value of credentialSubject, case insensitive.
- It can be applied to scenarios where did owner needs to be quickly located. The owner information is contained in the field of credentialSubject, and the fuzzy query can be used to locate the credential to realize the corresponding operation, such as revocation.
- Example: For example, if the account of a natural person needs to be restricted or closed, we can use this feature.