### PR TITLE
fix: invisible characters

### DIFF
--- a/k8s/helm/values.yaml
+++ b/k8s/helm/values.yaml
@@ -199,7 +199,7 @@ uiIssuerNode:
     issuerApiUiIssuerName: my issuer k8s
     issuerUiAuthUsername: user-ui
     issuerUiBlockExplorerUrlMumbai: https://mumbai.polygonscan.com
-    issuerUiBlockExplorerUrlAmoy: https://www.oklink.com/amoy‍
+    issuerUiBlockExplorerUrlAmoy: https://www.oklink.com/amoy
     issuerUiBlockExplorerUrlMain: https://polygonscan.com/
     issuerUiIpfsGatewayUrl: https://ipfs.io
     issuerApiUiName: issuer-node-ui-configmap


### PR DESCRIPTION
There are some invisible characters in this value, which causes the url to have `%E2%80%8D` after amoy