### PR TITLE
chore: add proofs to create claim endpoint

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -680,7 +680,7 @@ components:
           items:
             type: string
             x-omitempty: false
-            example: "[ BJJSignatureProof2021, Iden3SparseMerkleTreeProof]"
+            example: "BJJSignatureProof2021"
             enum: [ BJJSignatureProof2021, Iden3SparseMerkleTreeProof]
       example:
         credentialSchema: "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json/KYCAgeCredential-v3.json"

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -680,8 +680,8 @@ components:
           items:
             type: string
             x-omitempty: false
-            example: "BJJSignatureProof2021"
-            enum: [ BJJSignatureProof2021, Iden3SparseMerkleTreeProof]
+            example: "BJJSignature2021"
+            enum: [ BJJSignature2021, Iden3SparseMerkleTreeProof]
       example:
         credentialSchema: "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json/KYCAgeCredential-v3.json"
         type: "KYCAgeCredential"

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -675,6 +675,13 @@ components:
           $ref: '#/components/schemas/RefreshService'
         displayMethod:
           $ref: '#/components/schemas/DisplayMethod'
+        proofs:
+          type: array
+          items:
+            type: string
+            x-omitempty: false
+            example: "[ BJJSignatureProof2021, Iden3SparseMerkleTreeProof]"
+            enum: [ BJJSignatureProof2021, Iden3SparseMerkleTreeProof]
       example:
         credentialSchema: "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json/KYCAgeCredential-v3.json"
         type: "KYCAgeCredential"

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -23,7 +23,7 @@ const (
 
 // Defines values for CreateClaimRequestProofs.
 const (
-	BJJSignatureProof2021      CreateClaimRequestProofs = "BJJSignatureProof2021"
+	BJJSignature2021           CreateClaimRequestProofs = "BJJSignature2021"
 	Iden3SparseMerkleTreeProof CreateClaimRequestProofs = "Iden3SparseMerkleTreeProof"
 )
 

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -21,6 +21,12 @@ const (
 	BasicAuthScopes = "basicAuth.Scopes"
 )
 
+// Defines values for CreateClaimRequestProofs.
+const (
+	BJJSignatureProof2021      CreateClaimRequestProofs = "BJJSignatureProof2021"
+	Iden3SparseMerkleTreeProof CreateClaimRequestProofs = "Iden3SparseMerkleTreeProof"
+)
+
 // Defines values for CreateIdentityRequestDidMetadataType.
 const (
 	BJJ CreateIdentityRequestDidMetadataType = "BJJ"
@@ -53,17 +59,21 @@ type Config = []KeyValue
 
 // CreateClaimRequest defines model for CreateClaimRequest.
 type CreateClaimRequest struct {
-	CredentialSchema      string                 `json:"credentialSchema"`
-	CredentialSubject     map[string]interface{} `json:"credentialSubject"`
-	DisplayMethod         *DisplayMethod         `json:"displayMethod,omitempty"`
-	Expiration            *int64                 `json:"expiration,omitempty"`
-	MerklizedRootPosition *string                `json:"merklizedRootPosition,omitempty"`
-	RefreshService        *RefreshService        `json:"refreshService,omitempty"`
-	RevNonce              *uint64                `json:"revNonce,omitempty"`
-	SubjectPosition       *string                `json:"subjectPosition,omitempty"`
-	Type                  string                 `json:"type"`
-	Version               *uint32                `json:"version,omitempty"`
+	CredentialSchema      string                      `json:"credentialSchema"`
+	CredentialSubject     map[string]interface{}      `json:"credentialSubject"`
+	DisplayMethod         *DisplayMethod              `json:"displayMethod,omitempty"`
+	Expiration            *int64                      `json:"expiration,omitempty"`
+	MerklizedRootPosition *string                     `json:"merklizedRootPosition,omitempty"`
+	Proofs                *[]CreateClaimRequestProofs `json:"proofs,omitempty"`
+	RefreshService        *RefreshService             `json:"refreshService,omitempty"`
+	RevNonce              *uint64                     `json:"revNonce,omitempty"`
+	SubjectPosition       *string                     `json:"subjectPosition,omitempty"`
+	Type                  string                      `json:"type"`
+	Version               *uint32                     `json:"version,omitempty"`
 }
+
+// CreateClaimRequestProofs defines model for CreateClaimRequest.Proofs.
+type CreateClaimRequestProofs string
 
 // CreateClaimResponse defines model for CreateClaimResponse.
 type CreateClaimResponse struct {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -151,9 +151,6 @@ func (s *Server) CreateIdentity(ctx context.Context, request CreateIdentityReque
 
 // CreateClaim is claim creation controller
 func (s *Server) CreateClaim(ctx context.Context, request CreateClaimRequestObject) (CreateClaimResponseObject, error) {
-	const BJJSignatureProof2021 = "BJJSignatureProof2021"
-	const Iden3SparseMerkleTreeProof = "Iden3SparseMerkleTreeProof"
-
 	did, err := w3c.ParseDID(request.Identifier)
 	if err != nil {
 		return CreateClaim400JSONResponse{N400JSONResponse{Message: err.Error()}}, nil
@@ -169,11 +166,11 @@ func (s *Server) CreateClaim(ctx context.Context, request CreateClaimRequestObje
 		claimRequestProofs.Iden3SparseMerkleTreeProof = true
 	} else {
 		for _, proof := range *request.Body.Proofs {
-			if string(proof) == BJJSignatureProof2021 {
+			if string(proof) == string(verifiable.BJJSignatureProofType) {
 				claimRequestProofs.BJJSignatureProof2021 = true
 				continue
 			}
-			if string(proof) == Iden3SparseMerkleTreeProof {
+			if string(proof) == string(verifiable.Iden3SparseMerkleTreeProofType) {
 				claimRequestProofs.Iden3SparseMerkleTreeProof = true
 				continue
 			}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -477,6 +477,76 @@ func TestServer_CreateClaim(t *testing.T) {
 			},
 		},
 		{
+			name: "Happy path with two proofs",
+			auth: authOk,
+			did:  did,
+			body: CreateClaimRequest{
+				CredentialSchema: "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json/KYCAgeCredential-v3.json",
+				Type:             "KYCAgeCredential",
+				CredentialSubject: map[string]any{
+					"id":           "did:polygonid:polygon:mumbai:2qFDkNkWePjd6URt6kGQX14a7wVKhBZt8bpy7HZJZi",
+					"birthday":     19960425,
+					"documentType": 2,
+				},
+				Expiration: common.ToPointer(time.Now().Unix()),
+				Proofs: &[]CreateClaimRequestProofs{
+					"BJJSignature2021",
+					"Iden3SparseMerkleTreeProof",
+				},
+			},
+			expected: expected{
+				response:                    CreateClaim201JSONResponse{},
+				httpCode:                    http.StatusCreated,
+				createCredentialEventsCount: 1,
+			},
+		},
+		{
+			name: "Happy path with bjjSignature proof",
+			auth: authOk,
+			did:  did,
+			body: CreateClaimRequest{
+				CredentialSchema: "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json/KYCAgeCredential-v3.json",
+				Type:             "KYCAgeCredential",
+				CredentialSubject: map[string]any{
+					"id":           "did:polygonid:polygon:mumbai:2qFDkNkWePjd6URt6kGQX14a7wVKhBZt8bpy7HZJZi",
+					"birthday":     19960425,
+					"documentType": 2,
+				},
+				Expiration: common.ToPointer(time.Now().Unix()),
+				Proofs: &[]CreateClaimRequestProofs{
+					"BJJSignature2021",
+				},
+			},
+			expected: expected{
+				response:                    CreateClaim201JSONResponse{},
+				httpCode:                    http.StatusCreated,
+				createCredentialEventsCount: 1,
+			},
+		},
+		{
+			name: "Happy path with Iden3SparseMerkleTreeProof proof",
+			auth: authOk,
+			did:  did,
+			body: CreateClaimRequest{
+				CredentialSchema: "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json/KYCAgeCredential-v3.json",
+				Type:             "KYCAgeCredential",
+				CredentialSubject: map[string]any{
+					"id":           "did:polygonid:polygon:mumbai:2qFDkNkWePjd6URt6kGQX14a7wVKhBZt8bpy7HZJZi",
+					"birthday":     19960425,
+					"documentType": 2,
+				},
+				Expiration: common.ToPointer(time.Now().Unix()),
+				Proofs: &[]CreateClaimRequestProofs{
+					"Iden3SparseMerkleTreeProof",
+				},
+			},
+			expected: expected{
+				response:                    CreateClaim201JSONResponse{},
+				httpCode:                    http.StatusCreated,
+				createCredentialEventsCount: 0,
+			},
+		},
+		{
 			name: "Happy path with ipfs schema",
 			auth: authOk,
 			did:  did,

--- a/internal/api_ui/server.go
+++ b/internal/api_ui/server.go
@@ -343,7 +343,17 @@ func (s *Server) CreateCredential(ctx context.Context, request CreateCredentialR
 	if request.Body.SignatureProof == nil && request.Body.MtProof == nil {
 		return CreateCredential400JSONResponse{N400JSONResponse{Message: "you must to provide at least one proof type"}}, nil
 	}
-	req := ports.NewCreateClaimRequest(&s.cfg.APIUI.IssuerDID, request.Body.CredentialSchema, request.Body.CredentialSubject, request.Body.Expiration, request.Body.Type, nil, nil, nil, request.Body.SignatureProof, request.Body.MtProof, nil, true, s.cfg.CredentialStatus.CredentialStatusType, toVerifiableRefreshService(request.Body.RefreshService), nil,
+
+	claimRequestProofs := ports.ClaimRequestProofs{}
+	if request.Body.SignatureProof != nil && *request.Body.SignatureProof {
+		claimRequestProofs.BJJSignatureProof2021 = true
+	}
+
+	if request.Body.MtProof != nil && *request.Body.MtProof {
+		claimRequestProofs.Iden3SparseMerkleTreeProof = true
+	}
+
+	req := ports.NewCreateClaimRequest(&s.cfg.APIUI.IssuerDID, request.Body.CredentialSchema, request.Body.CredentialSubject, request.Body.Expiration, request.Body.Type, nil, nil, nil, claimRequestProofs, nil, true, s.cfg.CredentialStatus.CredentialStatusType, toVerifiableRefreshService(request.Body.RefreshService), nil,
 		toDisplayMethodService(request.Body.DisplayMethod))
 	resp, err := s.claimService.Save(ctx, req)
 	if err != nil {

--- a/internal/core/ports/claims_service.go
+++ b/internal/core/ports/claims_service.go
@@ -13,10 +13,15 @@ import (
 	comm "github.com/iden3/iden3comm/v2"
 	"github.com/iden3/iden3comm/v2/protocol"
 
-	"github.com/polygonid/sh-id-platform/internal/common"
 	"github.com/polygonid/sh-id-platform/internal/core/domain"
 	"github.com/polygonid/sh-id-platform/internal/sqltools"
 )
+
+// ClaimRequestProofs - defines the proofs that can be requested for a claim
+type ClaimRequestProofs struct {
+	BJJSignatureProof2021      bool
+	Iden3SparseMerkleTreeProof bool
+}
 
 // CreateClaimRequest struct
 type CreateClaimRequest struct {
@@ -112,22 +117,14 @@ func NewClaimsFilter(schemaHash, schemaType, subject, queryField, queryValue *st
 }
 
 // NewCreateClaimRequest returns a new claim object with the given parameters
-func NewCreateClaimRequest(did *w3c.DID, credentialSchema string, credentialSubject map[string]any, expiration *time.Time, typ string, cVersion *uint32, subjectPos *string, merklizedRootPosition *string, sigProof *bool, mtProof *bool, linkID *uuid.UUID, singleIssuer bool, credentialStatusType verifiable.CredentialStatusType, refreshService *verifiable.RefreshService, revNonce *uint64, displayMethod *verifiable.DisplayMethod) *CreateClaimRequest {
-	if sigProof == nil {
-		sigProof = common.ToPointer(false)
-	}
-
-	if mtProof == nil {
-		mtProof = common.ToPointer(false)
-	}
-
+func NewCreateClaimRequest(did *w3c.DID, credentialSchema string, credentialSubject map[string]any, expiration *time.Time, typ string, cVersion *uint32, subjectPos *string, merklizedRootPosition *string, claimRequestProofs ClaimRequestProofs, linkID *uuid.UUID, singleIssuer bool, credentialStatusType verifiable.CredentialStatusType, refreshService *verifiable.RefreshService, revNonce *uint64, displayMethod *verifiable.DisplayMethod) *CreateClaimRequest {
 	req := &CreateClaimRequest{
 		DID:               did,
 		Schema:            credentialSchema,
 		CredentialSubject: credentialSubject,
 		Type:              typ,
-		SignatureProof:    *sigProof,
-		MTProof:           *mtProof,
+		SignatureProof:    claimRequestProofs.BJJSignatureProof2021,
+		MTProof:           claimRequestProofs.Iden3SparseMerkleTreeProof,
 		RefreshService:    refreshService,
 		DisplayMethod:     displayMethod,
 	}

--- a/internal/core/services/link.go
+++ b/internal/core/services/link.go
@@ -15,7 +15,6 @@ import (
 	"github.com/iden3/iden3comm/v2/protocol"
 	"github.com/jackc/pgx/v4"
 
-	"github.com/polygonid/sh-id-platform/internal/common"
 	"github.com/polygonid/sh-id-platform/internal/core/domain"
 	"github.com/polygonid/sh-id-platform/internal/core/event"
 	"github.com/polygonid/sh-id-platform/internal/core/ports"
@@ -246,6 +245,11 @@ func (ls *Link) IssueClaim(ctx context.Context, sessionID string, issuerDID w3c.
 		log.Error(ctx, "cannot fetch the schema", "err", err)
 		return err
 	}
+
+	claimRequestProofs := ports.ClaimRequestProofs{
+		BJJSignatureProof2021:      link.CredentialSignatureProof,
+		Iden3SparseMerkleTreeProof: link.CredentialMTPProof,
+	}
 	if len(issuedByUser) == 0 {
 		link.CredentialSubject["id"] = userDID.String()
 
@@ -255,8 +259,7 @@ func (ls *Link) IssueClaim(ctx context.Context, sessionID string, issuerDID w3c.
 			link.CredentialExpiration,
 			schema.Type,
 			nil, nil, nil,
-			common.ToPointer(link.CredentialSignatureProof),
-			common.ToPointer(link.CredentialMTPProof),
+			claimRequestProofs,
 			&linkID,
 			true,
 			credentialStatusType,

--- a/internal/core/services/tests/identity_test.go
+++ b/internal/core/services/tests/identity_test.go
@@ -71,7 +71,7 @@ func Test_identity_UpdateState(t *testing.T) {
 		merklizedRootPosition := "index"
 		_, err = claimsService.Save(ctx, ports.NewCreateClaimRequest(did, schema, credentialSubject,
 			common.ToPointer(time.Now()), typeC, nil, nil, &merklizedRootPosition,
-			common.ToPointer(true), common.ToPointer(true), nil, false,
+			ports.ClaimRequestProofs{BJJSignatureProof2021: true, Iden3SparseMerkleTreeProof: true}, nil, false,
 			verifiable.Iden3commRevocationStatusV1, nil, nil, nil))
 
 		assert.NoError(t, err)
@@ -93,7 +93,7 @@ func Test_identity_UpdateState(t *testing.T) {
 		merklizedRootPosition := "index"
 		_, err = claimsService.Save(ctx, ports.NewCreateClaimRequest(did, schema, credentialSubject,
 			common.ToPointer(time.Now()), typeC, nil, nil, &merklizedRootPosition,
-			common.ToPointer(false), common.ToPointer(true), nil, false,
+			ports.ClaimRequestProofs{BJJSignatureProof2021: true, Iden3SparseMerkleTreeProof: true}, nil, false,
 			verifiable.Iden3commRevocationStatusV1, nil, nil, nil))
 
 		assert.NoError(t, err)
@@ -115,7 +115,7 @@ func Test_identity_UpdateState(t *testing.T) {
 		merklizedRootPosition := "index"
 		claim, err := claimsService.Save(ctx, ports.NewCreateClaimRequest(did, schema, credentialSubject,
 			common.ToPointer(time.Now()), typeC, nil, nil, &merklizedRootPosition,
-			common.ToPointer(false), common.ToPointer(true), nil, false,
+			ports.ClaimRequestProofs{BJJSignatureProof2021: false, Iden3SparseMerkleTreeProof: true}, nil, false,
 			verifiable.Iden3commRevocationStatusV1, nil, nil, nil))
 
 		assert.NoError(t, err)
@@ -141,7 +141,7 @@ func Test_identity_UpdateState(t *testing.T) {
 		merklizedRootPosition := "index"
 		claimMTP, err := claimsService.Save(ctx, ports.NewCreateClaimRequest(did, schema, credentialSubject,
 			common.ToPointer(time.Now()), typeC, nil, nil, &merklizedRootPosition,
-			common.ToPointer(false), common.ToPointer(true), nil, false,
+			ports.ClaimRequestProofs{BJJSignatureProof2021: false, Iden3SparseMerkleTreeProof: true}, nil, false,
 			verifiable.Iden3commRevocationStatusV1, nil, nil, nil))
 
 		assert.NoError(t, err)
@@ -163,7 +163,7 @@ func Test_identity_UpdateState(t *testing.T) {
 
 		claimSIG, err := claimsService.Save(ctx, ports.NewCreateClaimRequest(did, schema, credentialSubject,
 			common.ToPointer(time.Now()), typeC, nil, nil, &merklizedRootPosition,
-			common.ToPointer(true), common.ToPointer(false), nil, false,
+			ports.ClaimRequestProofs{BJJSignatureProof2021: true, Iden3SparseMerkleTreeProof: false}, nil, false,
 			verifiable.Iden3commRevocationStatusV1, nil, nil, nil))
 
 		assert.NoError(t, err)
@@ -190,7 +190,7 @@ func Test_identity_UpdateState(t *testing.T) {
 		merklizedRootPosition := "index"
 		_, err = claimsService.Save(ctx, ports.NewCreateClaimRequest(did, schema, credentialSubject,
 			common.ToPointer(time.Now()), typeC, nil, nil, &merklizedRootPosition,
-			common.ToPointer(true), common.ToPointer(false), nil, false,
+			ports.ClaimRequestProofs{BJJSignatureProof2021: true, Iden3SparseMerkleTreeProof: false}, nil, false,
 			verifiable.Iden3commRevocationStatusV1, nil, nil, nil))
 
 		assert.NoError(t, err)
@@ -205,7 +205,7 @@ func Test_identity_UpdateState(t *testing.T) {
 		merklizedRootPosition := "index"
 		claim, err := claimsService.Save(ctx, ports.NewCreateClaimRequest(did, schema, credentialSubject,
 			common.ToPointer(time.Now()), typeC, nil, nil, &merklizedRootPosition,
-			common.ToPointer(true), common.ToPointer(false), nil, false,
+			ports.ClaimRequestProofs{BJJSignatureProof2021: true, Iden3SparseMerkleTreeProof: false}, nil, false,
 			verifiable.Iden3commRevocationStatusV1, nil, nil, nil))
 
 		assert.NoError(t, err)

--- a/internal/core/services/tests/link_test.go
+++ b/internal/core/services/tests/link_test.go
@@ -79,7 +79,7 @@ func Test_link_issueClaim(t *testing.T) {
 	typeC := "KYCAgeCredential"
 
 	merklizedRootPosition := "index"
-	_, err = claimsService.Save(context.Background(), ports.NewCreateClaimRequest(did, schemaUrl, credentialSubject, common.ToPointer(time.Now()), typeC, nil, nil, &merklizedRootPosition, common.ToPointer(true), common.ToPointer(true), nil, false, verifiable.Iden3commRevocationStatusV1, nil, nil, nil))
+	_, err = claimsService.Save(context.Background(), ports.NewCreateClaimRequest(did, schemaUrl, credentialSubject, common.ToPointer(time.Now()), typeC, nil, nil, &merklizedRootPosition, ports.ClaimRequestProofs{BJJSignatureProof2021: true, Iden3SparseMerkleTreeProof: true}, nil, false, verifiable.Iden3commRevocationStatusV1, nil, nil, nil))
 	assert.NoError(t, err)
 
 	linkRepository := repositories.NewLink(*storage)


### PR DESCRIPTION
## Notes
* Add proofs field to the create claim body endpoint in core API.
* The values allowed are:  BJJSignature2021┃Iden3SparseMerkleTreeProof

With this feature the user can specify the type of proof for the claim