### PR TITLE
chore: add kms local storage

### DIFF
--- a/.env-issuer.sample
+++ b/.env-issuer.sample
@@ -14,6 +14,10 @@ ISSUER_API_AUTH_USER=user-issuer
 ISSUER_API_AUTH_PASSWORD=password-issuer
 ISSUER_KEY_STORE_ADDRESS=http://vault:8200
 ISSUER_KEY_STORE_PLUGIN_IDEN3_MOUNT_PATH=iden3
+# Could be either localstorage or vault
+ISSUER_KMS_PLUGIN=localstorage
+# if the plugin is localstorage, you can specify the file path (default path is current directory)
+ISSUER_KMS_PLUGIN_LOCAL_STORAGE_FILE_PATH=
 
 ISSUER_PROVER_SERVER_URL=http://localhost:8002
 ISSUER_PROVER_TIMEOUT=600s

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,10 @@ api-ui: $(BIN)/oapi-codegen
 up:
 	$(DOCKER_COMPOSE_INFRA_CMD) up -d redis postgres vault
 
+.PHONY: up/localstorage
+ up/localstorage:
+	$(DOCKER_COMPOSE_INFRA_CMD) up -d redis postgres
+
 .PHONY: run
 run:
 	$(eval DELETE_FILE = $(shell if [ -f ./.env-ui ]; then echo "false"; else echo "true"; fi))
@@ -154,6 +158,12 @@ lint-fix: $(BIN)/golangci-lint
 add-private-key:
 	docker exec issuer-vault-1 \
 	vault write iden3/import/pbkey key_type=ethereum private_key=$(private_key)
+
+# usage: make private_key=xxx add-private-key-localstorage
+.PHONY: add-private-key-localstorage
+add-private-key-localstorage:
+	docker exec issuer-api-1 \
+	./kms_local_storage_priv_key_importer --privateKey=$(private_key)
 
 .PHONY: print-vault-token
 print-vault-token:

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ ISSUER_KMS_PLUGIN=localstorage
 When the issuer-api-1 container is running (after execute make run), you have to add your metamask private key with the following command 
 
 ```bash
- make private_key=4b3XXX add-private-key-localstorage
+make private_key=4b3XXX add-private-key-localstorage
 ```
 If you want to use Vault just change the `ISSUER_KMS_PLUGIN` to `vault` and follow the steps in the [Deploy Issuer Node Infrastructure](#Deploy-Issuer-Node-Infrastructure) section. 
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,23 @@ make restart-ui
 ```
 ---
 
+## Issuer Node V2 Notes
+
+### Running issuer node with local storage file instead of Vault
+Setup environment variables in `.env-issuer` file:
+
+```bash
+ISSUER_KMS_PLUGIN=localstorage 
+```
+
+When the issuer-api-1 container is running (after execute make run), you have to add your metamask private key with the following command 
+
+```bash
+ make private_key=4b3XXX add-private-key-localstorage
+```
+If you want to use Vault just change the `ISSUER_KMS_PLUGIN` to `vault` and follow the steps in the [Deploy Issuer Node Infrastructure](#Deploy-Issuer-Node-Infrastructure) section. 
+
+
 ## Quick Start Demo
 
 This [Quick Start Demo](https://devs.polygonid.com/docs/quick-start-demo/) will walk you through the process of **issuing** and **verifying** your **first credential**.

--- a/cmd/kms_local_storage_priv_key_importer/main.go
+++ b/cmd/kms_local_storage_priv_key_importer/main.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"os"
+
+	"github.com/joho/godotenv"
+
+	"github.com/polygonid/sh-id-platform/internal/config"
+	"github.com/polygonid/sh-id-platform/internal/kms"
+	"github.com/polygonid/sh-id-platform/internal/log"
+)
+
+const (
+	// IssuerKmsPlugin is the environment variable that defines the issuer kms plugin
+	IssuerKmsPlugin = "ISSUER_KMS_PLUGIN"
+	// IssuerKmsPluginLocalStorageFilePath is the environment variable that defines the issuer kms plugin local storage file path
+	IssuerKmsPluginLocalStorageFilePath = "ISSUER_KMS_PLUGIN_LOCAL_STORAGE_FILE_PATH"
+	jsonKeyPath                         = "key_path"
+	jsonKeyType                         = "key_type"
+	jsonKeyData                         = "key_data"
+	pbkey                               = "pbkey"
+	ethereum                            = "ethereum"
+	pluginFolderPath                    = "./localstoragekeys"
+	envFile                             = ".env-issuer"
+)
+
+type localStorageBJJKeyProviderFileContent struct {
+	KeyType    string `json:"key_type"`
+	KeyPath    string `json:"key_path"`
+	PrivateKey string `json:"private_key"`
+}
+
+func main() {
+	fPrivateKey := flag.String("privateKey", "", "metamask private key")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	flag.Parse()
+
+	if *fPrivateKey == "" {
+		log.Error(ctx, "private key is required")
+		return
+	}
+
+	if os.Getenv(IssuerKmsPlugin) == "" {
+		err := godotenv.Load(envFile)
+		if err != nil {
+			log.Error(ctx, "Error loading .env-issuer file")
+		}
+	}
+
+	if os.Getenv(IssuerKmsPlugin) == "" || os.Getenv(IssuerKmsPlugin) != config.LocalStorage {
+		log.Error(ctx, "issuer kms plugin is not set or is not local storage", "plugin: ", os.Getenv(IssuerKmsPlugin))
+		return
+	}
+
+	if os.Getenv(IssuerKmsPluginLocalStorageFilePath) == "" {
+		err := godotenv.Load(envFile)
+		if err != nil {
+			log.Error(ctx, "Error loading .env-issuer file")
+		}
+	}
+
+	pluginFolderPathVar := ""
+	if os.Getenv(IssuerKmsPluginLocalStorageFilePath) != "" {
+		pluginFolderPathVar = os.Getenv(IssuerKmsPluginLocalStorageFilePath)
+	} else {
+		pluginFolderPathVar = pluginFolderPath
+	}
+
+	_, err := kms.OpenLocalPath(pluginFolderPathVar)
+	if err != nil {
+		log.Error(ctx, "cannot open local storage path", "err", err)
+		return
+	}
+
+	material := make(map[string]string)
+	material[jsonKeyPath] = pbkey
+	material[jsonKeyType] = ethereum
+	material[jsonKeyData] = *fPrivateKey
+
+	file := pluginFolderPath + "/" + kms.LocalStorageFileName
+	if err := saveKeyMaterialToFile(ctx, file, material); err != nil {
+		log.Error(ctx, "cannot save key material to file", "err", err)
+		return
+	}
+
+	log.Info(ctx, "private key saved to file")
+}
+
+func saveKeyMaterialToFile(ctx context.Context, file string, keyMaterial map[string]string) error {
+	localStorageFileContent, err := readContentFile(ctx, file)
+	if err != nil {
+		return err
+	}
+
+	for _, keyMaterialContentFile := range localStorageFileContent {
+		if keyMaterialContentFile.KeyPath == keyMaterial[jsonKeyPath] {
+			log.Error(ctx, "key already exists", "keyPath", keyMaterial[jsonKeyPath])
+			return errors.New("key already exists")
+		}
+	}
+
+	localStorageFileContent = append(localStorageFileContent, localStorageBJJKeyProviderFileContent{
+		KeyPath:    keyMaterial[jsonKeyPath],
+		KeyType:    keyMaterial[jsonKeyType],
+		PrivateKey: keyMaterial[jsonKeyData],
+	})
+
+	newFileContent, err := json.Marshal(localStorageFileContent)
+	if err != nil {
+		log.Error(ctx, "cannot marshal file content", "err", err)
+		return err
+	}
+	// nolint: all
+	if err := os.WriteFile(file, newFileContent, 0644); err != nil {
+		log.Error(ctx, "cannot write file", "err", err)
+		return err
+	}
+
+	return nil
+}
+
+func readContentFile(ctx context.Context, file string) ([]localStorageBJJKeyProviderFileContent, error) {
+	fileContent, err := os.ReadFile(file)
+	if err != nil {
+		log.Error(ctx, "cannot read file", "err", err, "file", file)
+		return nil, err
+	}
+
+	var localStorageFileContent []localStorageBJJKeyProviderFileContent
+	if err := json.Unmarshal(fileContent, &localStorageFileContent); err != nil {
+		log.Error(ctx, "cannot unmarshal file content", "err", err)
+		return nil, err
+	}
+
+	return localStorageFileContent, nil
+}

--- a/infrastructure/local/docker-compose.yml
+++ b/infrastructure/local/docker-compose.yml
@@ -25,6 +25,8 @@ services:
     env_file:
       - ../../.env-api
       - ../../.env-issuer
+    volumes:
+      - ../../localstoragekeys:/localstoragekeys:rw
     healthcheck:
       test: [ "CMD", "curl", "-f", "host.docker.internal:3001/status" ]
       interval: 10s

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,32 +26,37 @@ import (
 const (
 	CIConfigPath = "/home/runner/work/sh-id-platform/sh-id-platform/" // CIConfigPath variable contain the CI configuration path
 	ipfsGateway  = "https://cloudflare-ipfs.com"
+
+	// LocalStorage is the local storage plugin
+	LocalStorage = "localstorage"
 )
 
 // Configuration holds the project configuration
 type Configuration struct {
-	ServerUrl                    string
-	ServerPort                   int
-	NativeProofGenerationEnabled bool
-	Database                     Database      `mapstructure:"Database"`
-	Cache                        Cache         `mapstructure:"Cache"`
-	HTTPBasicAuth                HTTPBasicAuth `mapstructure:"HTTPBasicAuth"`
-	KeyStore                     KeyStore      `mapstructure:"KeyStore"`
-	Log                          Log           `mapstructure:"Log"`
-	Ethereum                     Ethereum      `mapstructure:"Ethereum"`
-	Prover                       Prover        `mapstructure:"Prover"`
-	Circuit                      Circuit       `mapstructure:"Circuit"`
-	PublishingKeyPath            string        `mapstructure:"PublishingKeyPath"`
-	OnChainCheckStatusFrequency  time.Duration `mapstructure:"OnChainCheckStatusFrequency"`
-	SchemaCache                  *bool         `mapstructure:"SchemaCache"`
-	APIUI                        APIUI         `mapstructure:"APIUI"`
-	IPFS                         IPFS          `mapstructure:"IPFS"`
-	VaultUserPassAuthEnabled     bool
-	VaultUserPassAuthPassword    string
-	CredentialStatus             CredentialStatus   `mapstructure:"CredentialStatus"`
-	CustomDIDMethods             []CustomDIDMethods `mapstructure:"-"`
-	MediaTypeManager             MediaTypeManager   `mapstructure:"MediaTypeManager"`
-	NetworkResolverPath          string             `mapstructure:"NetworkResolverPath"`
+	ServerUrl                     string
+	ServerPort                    int
+	NativeProofGenerationEnabled  bool
+	Database                      Database      `mapstructure:"Database"`
+	Cache                         Cache         `mapstructure:"Cache"`
+	HTTPBasicAuth                 HTTPBasicAuth `mapstructure:"HTTPBasicAuth"`
+	KeyStore                      KeyStore      `mapstructure:"KeyStore"`
+	Log                           Log           `mapstructure:"Log"`
+	Ethereum                      Ethereum      `mapstructure:"Ethereum"`
+	Prover                        Prover        `mapstructure:"Prover"`
+	Circuit                       Circuit       `mapstructure:"Circuit"`
+	PublishingKeyPath             string        `mapstructure:"PublishingKeyPath"`
+	OnChainCheckStatusFrequency   time.Duration `mapstructure:"OnChainCheckStatusFrequency"`
+	SchemaCache                   *bool         `mapstructure:"SchemaCache"`
+	APIUI                         APIUI         `mapstructure:"APIUI"`
+	IPFS                          IPFS          `mapstructure:"IPFS"`
+	VaultUserPassAuthEnabled      bool
+	VaultUserPassAuthPassword     string
+	CredentialStatus              CredentialStatus   `mapstructure:"CredentialStatus"`
+	CustomDIDMethods              []CustomDIDMethods `mapstructure:"-"`
+	MediaTypeManager              MediaTypeManager   `mapstructure:"MediaTypeManager"`
+	NetworkResolverPath           string             `mapstructure:"NetworkResolverPath"`
+	KmsPlugin                     string             `mapstructure:"KmsPlugin"`
+	KmsPluginLocalStorageFilePath string             `mapstructure:"KmsPluginLocalStorageFilePath"`
 }
 
 // Database has the database configuration
@@ -446,6 +451,8 @@ func bindEnv() {
 	_ = viper.BindEnv("VaultUserPassAuthEnabled", "ISSUER_VAULT_USERPASS_AUTH_ENABLED")
 	_ = viper.BindEnv("VaultUserPassAuthPassword", "ISSUER_VAULT_USERPASS_AUTH_PASSWORD")
 	_ = viper.BindEnv("NetworkResolverPath", "ISSUER_RESOLVER_PATH")
+	_ = viper.BindEnv("KmsPlugin", "ISSUER_KMS_PLUGIN")
+	_ = viper.BindEnv("KmsPluginLocalStorageFilePath", "ISSUER_KMS_PLUGIN_LOCAL_STORAGE_FILE_PATH")
 
 	_ = viper.BindEnv("APIUI.ServerPort", "ISSUER_API_UI_SERVER_PORT")
 	_ = viper.BindEnv("APIUI.ServerURL", "ISSUER_API_UI_SERVER_URL")
@@ -547,6 +554,16 @@ func checkEnvVars(ctx context.Context, cfg *Configuration) {
 	if cfg.NetworkResolverPath == "" {
 		log.Info(ctx, "ISSUER_RESOLVER_PATH value is missing")
 		cfg.NetworkResolverPath = "./resolvers_settings.yaml"
+	}
+
+	if cfg.KmsPlugin == "" {
+		log.Info(ctx, "ISSUER_KMS_PLUGIN value is missing, using default value: localstorage")
+		cfg.KmsPlugin = LocalStorage
+	}
+
+	if cfg.KmsPlugin == LocalStorage && cfg.KmsPluginLocalStorageFilePath == "" {
+		log.Info(ctx, "ISSUER_KMS_PLUGIN_LOCAL_STORAGE_FOLDER value is missing, using default value: ./localstoragekeys")
+		cfg.KmsPluginLocalStorageFilePath = "./localstoragekeys"
 	}
 
 	if cfg.APIUI.KeyType == "" {

--- a/internal/kms/local_storage_bjj_key_provider.go
+++ b/internal/kms/local_storage_bjj_key_provider.go
@@ -103,7 +103,7 @@ func (ls *localStorageBJJKeyProvider) Sign(ctx context.Context, keyID KeyID, dat
 
 // ListByIdentity lists keys by identity
 func (ls *localStorageBJJKeyProvider) ListByIdentity(ctx context.Context, identity w3c.DID) ([]KeyID, error) {
-	return ls.localStorageFileManager.searchByIdentityInFile(ctx, identity)
+	return ls.localStorageFileManager.searchByIdentityInFile(ctx, identity, ls.keyType)
 }
 
 // LinkToIdentity links key to identity

--- a/internal/kms/local_storage_bjj_key_provider.go
+++ b/internal/kms/local_storage_bjj_key_provider.go
@@ -1,0 +1,153 @@
+package kms
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"math/big"
+	"regexp"
+
+	"github.com/iden3/go-iden3-core/v2/w3c"
+	"github.com/iden3/go-iden3-crypto/babyjub"
+	"github.com/iden3/go-iden3-crypto/utils"
+
+	"github.com/polygonid/sh-id-platform/internal/log"
+)
+
+type localStorageBJJKeyProviderFileContent struct {
+	KeyType    string `json:"key_type"`
+	KeyPath    string `json:"key_path"`
+	PrivateKey string `json:"private_key"`
+}
+
+type localStorageBJJKeyProvider struct {
+	keyType                 KeyType
+	reIdenKeyPathHex        *regexp.Regexp // RE of key path bounded to identity
+	reAnonKeyPathHex        *regexp.Regexp // RE of key path not bounded to identity
+	localStorageFileManager LocalStorageFileManager
+}
+
+// NewLocalStorageBJJKeyProvider - creates new key provider for BabyJubJub keys stored in local storage
+func NewLocalStorageBJJKeyProvider(keyType KeyType, localStorageFileManager LocalStorageFileManager) KeyProvider {
+	keyTypeRE := regexp.QuoteMeta(string(keyType))
+	reIdenKeyPathHex := regexp.MustCompile("^(?i).*/" + keyTypeRE + ":([a-f0-9]{64})$")
+	reAnonKeyPathHex := regexp.MustCompile("^(?i)" + keyTypeRE + ":([a-f0-9]{64})$")
+	return &localStorageBJJKeyProvider{
+		keyType:                 keyType,
+		localStorageFileManager: localStorageFileManager,
+		reIdenKeyPathHex:        reIdenKeyPathHex,
+		reAnonKeyPathHex:        reAnonKeyPathHex,
+	}
+}
+
+// New generates random a KeyID.
+func (ls *localStorageBJJKeyProvider) New(identity *w3c.DID) (KeyID, error) {
+	ctx := context.Background()
+	bjjPrivateKey := babyjub.NewRandPrivKey()
+	keyID := KeyID{
+		Type: ls.keyType,
+		ID:   keyPath(identity, ls.keyType, bjjPrivateKey.Public().String()),
+	}
+	keyMaterial := map[string]string{
+		jsonKeyType: string(keyID.Type),
+		jsonKeyData: hex.EncodeToString(bjjPrivateKey[:]),
+	}
+	if err := ls.localStorageFileManager.saveKeyMaterialToFile(ctx, keyMaterial, keyID.ID); err != nil {
+		return KeyID{}, err
+	}
+	return keyID, nil
+}
+
+// PublicKey returns bytes representation for public key for specified key ID
+func (ls *localStorageBJJKeyProvider) PublicKey(keyID KeyID) ([]byte, error) {
+	if keyID.Type != ls.keyType {
+		return nil, ErrIncorrectKeyType
+	}
+
+	ss := ls.reAnonKeyPathHex.FindStringSubmatch(keyID.ID)
+	if ss == nil {
+		ss = ls.reIdenKeyPathHex.FindStringSubmatch(keyID.ID)
+	}
+	if len(ss) != partsNumber {
+		return nil, errors.New("unable to get public key from key ID")
+	}
+
+	val, err := hex.DecodeString(ss[1])
+	return val, err
+}
+
+// Sign signs digest with private key
+func (ls *localStorageBJJKeyProvider) Sign(ctx context.Context, keyID KeyID, data []byte) ([]byte, error) {
+	if len(data) > defaultLength {
+		return nil, errors.New("data to sign is too large")
+	}
+
+	i := new(big.Int).SetBytes(utils.SwapEndianness(data))
+	if !utils.CheckBigIntInField(i) {
+		return nil, errors.New("data to sign is too large")
+	}
+
+	privKeyData, err := ls.privateKey(ctx, keyID)
+	if err != nil {
+		return nil, err
+	}
+
+	privKey, err := decodeBJJPrivateKey(privKeyData)
+	if err != nil {
+		return nil, err
+	}
+
+	sig := privKey.SignPoseidon(i).Compress()
+	return sig[:], nil
+}
+
+// ListByIdentity lists keys by identity
+func (ls *localStorageBJJKeyProvider) ListByIdentity(ctx context.Context, identity w3c.DID) ([]KeyID, error) {
+	return ls.localStorageFileManager.searchByIdentityInFile(ctx, identity)
+}
+
+// LinkToIdentity links key to identity
+func (ls *localStorageBJJKeyProvider) LinkToIdentity(ctx context.Context, keyID KeyID, identity w3c.DID) (KeyID, error) {
+	if keyID.Type != ls.keyType {
+		return keyID, ErrIncorrectKeyType
+	}
+
+	err := ls.localStorageFileManager.searchKeyMaterialInFileAndReplace(ctx, keyID.ID, identity)
+	if err != nil {
+		return keyID, err
+	}
+
+	keyID.ID = identity.String()
+	return keyID, nil
+}
+
+func (ls *localStorageBJJKeyProvider) privateKey(ctx context.Context, keyID KeyID) ([]byte, error) {
+	if keyID.Type != ls.keyType {
+		return nil, ErrIncorrectKeyType
+	}
+
+	if !ls.reAnonKeyPathHex.MatchString(keyID.ID) &&
+		!ls.reIdenKeyPathHex.MatchString(keyID.ID) {
+		log.Error(ctx, "incorrect key ID", "keyID", keyID)
+		return nil, errors.New("incorrect key ID")
+	}
+
+	privateKey, err := ls.localStorageFileManager.searchPrivateKeyInFile(ctx, keyID)
+	if err != nil {
+		log.Error(ctx, "cannot get private key", "err", err, "keyID", keyID)
+		return nil, err
+	}
+
+	val, err := hex.DecodeString(privateKey)
+	if err != nil {
+		log.Error(ctx, "cannot decode private key", "err", err, "keyID", keyID)
+		return nil, err
+	}
+
+	if len(val) != defaultLength {
+		log.Error(ctx, "incorrect private key", "keyID", keyID)
+		return nil, errors.New("incorrect private key")
+	}
+
+	return val, nil
+}

--- a/internal/kms/local_storage_eth_key_provider.go
+++ b/internal/kms/local_storage_eth_key_provider.go
@@ -1,0 +1,153 @@
+package kms
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"errors"
+	"regexp"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/iden3/go-iden3-core/v2/w3c"
+
+	"github.com/polygonid/sh-id-platform/internal/log"
+)
+
+type localStorageEthKeyProvider struct {
+	keyType                 KeyType
+	reIdenKeyPathHex        *regexp.Regexp // RE of key path bounded to identity
+	localStorageFileManager LocalStorageFileManager
+}
+
+// NewLocalStorageEthKeyProvider - creates new key provider for Ethereum keys stored in local storage
+func NewLocalStorageEthKeyProvider(keyType KeyType, localStorageFileManager LocalStorageFileManager) KeyProvider {
+	keyTypeRE := regexp.QuoteMeta(string(keyType))
+	reIdenKeyPathHex := regexp.MustCompile("^(?i).*/" + keyTypeRE + ":([a-f0-9]{64})$")
+	return &localStorageEthKeyProvider{
+		keyType:                 keyType,
+		localStorageFileManager: localStorageFileManager,
+		reIdenKeyPathHex:        reIdenKeyPathHex,
+	}
+}
+
+func (ls *localStorageEthKeyProvider) New(identity *w3c.DID) (KeyID, error) {
+	ctx := context.Background()
+	keyID := KeyID{Type: ls.keyType}
+
+	ethPrivKey, err := crypto.GenerateKey()
+	if err != nil {
+		return keyID, err
+	}
+
+	keyMaterial := map[string]string{
+		jsonKeyType: string(KeyTypeEthereum),
+		jsonKeyData: hex.EncodeToString(crypto.FromECDSA(ethPrivKey)),
+	}
+
+	pubKey, ok := ethPrivKey.Public().(*ecdsa.PublicKey)
+	if !ok {
+		return keyID, errors.New("unexpected public key type")
+	}
+	pubKeyBytes := crypto.CompressPubkey(pubKey)
+	pubKeyHex := hex.EncodeToString(pubKeyBytes)
+	keyID.ID = keyPath(identity, ls.keyType, pubKeyHex)
+
+	if err := ls.localStorageFileManager.saveKeyMaterialToFile(ctx, keyMaterial, keyID.ID); err != nil {
+		return KeyID{}, err
+	}
+	return keyID, nil
+}
+
+func (ls *localStorageEthKeyProvider) PublicKey(keyID KeyID) ([]byte, error) {
+	ctx := context.Background()
+	if keyID.Type != ls.keyType {
+		return nil, ErrIncorrectKeyType
+	}
+
+	ss := ls.reIdenKeyPathHex.FindStringSubmatch(keyID.ID)
+	if len(ss) != partsNumber {
+		// if not found. try get public key from private key.
+		pkBytes, err := ls.privateKey(ctx, keyID)
+		if err != nil {
+			return nil, errors.New("unable to get private key for build public key")
+		}
+		pk, err := decodeETHPrivateKey(pkBytes)
+		if err != nil {
+			return nil, err
+		}
+		switch v := pk.Public().(type) {
+		case *ecdsa.PublicKey:
+			return crypto.CompressPubkey(v), nil
+		default:
+			return nil, errors.New("unable to get public key from key ID")
+		}
+	}
+
+	val, err := hex.DecodeString(ss[1])
+
+	return val, err
+}
+
+func (ls *localStorageEthKeyProvider) Sign(ctx context.Context, keyID KeyID, data []byte) ([]byte, error) {
+	privKeyData, err := ls.privateKey(ctx, keyID)
+	if err != nil {
+		return nil, err
+	}
+
+	privKey, err := decodeETHPrivateKey(privKeyData)
+	if err != nil {
+		return nil, err
+	}
+
+	sig, err := crypto.Sign(data, privKey)
+	return sig, err
+}
+
+func (ls *localStorageEthKeyProvider) LinkToIdentity(ctx context.Context, keyID KeyID, identity w3c.DID) (KeyID, error) {
+	if keyID.Type != ls.keyType {
+		return keyID, ErrIncorrectKeyType
+	}
+
+	err := ls.localStorageFileManager.searchKeyMaterialInFileAndReplace(ctx, keyID.ID, identity)
+	if err != nil {
+		return keyID, err
+	}
+
+	keyID.ID = identity.String()
+	return keyID, nil
+}
+
+// ListByIdentity lists keys by identity
+func (ls *localStorageEthKeyProvider) ListByIdentity(ctx context.Context, identity w3c.DID) ([]KeyID, error) {
+	return ls.localStorageFileManager.searchByIdentityInFile(ctx, identity)
+}
+
+// nolint
+func (ls *localStorageEthKeyProvider) privateKey(ctx context.Context, keyID KeyID) ([]byte, error) {
+	if keyID.Type != ls.keyType {
+		return nil, ErrIncorrectKeyType
+	}
+
+	if keyID.ID == "" {
+		return nil, errors.New("key ID is empty")
+	}
+
+	privateKey, err := ls.localStorageFileManager.searchPrivateKeyInFile(context.Background(), keyID)
+	if err != nil {
+		log.Error(ctx, "cannot get private key", "err", err, "keyID", keyID)
+		return nil, err
+	}
+
+	val, err := hex.DecodeString(privateKey)
+	if err != nil {
+		log.Error(ctx, "cannot decode private key", "err", err, "keyID", keyID)
+		return nil, err
+	}
+
+	if len(val) != defaultLength {
+		log.Error(ctx, "incorrect private key", "keyID", keyID)
+		return nil, errors.New("incorrect private key")
+	}
+
+	return val, nil
+}

--- a/internal/kms/local_storage_eth_key_provider.go
+++ b/internal/kms/local_storage_eth_key_provider.go
@@ -48,6 +48,7 @@ func (ls *localStorageEthKeyProvider) New(identity *w3c.DID) (KeyID, error) {
 	if !ok {
 		return keyID, errors.New("unexpected public key type")
 	}
+
 	pubKeyBytes := crypto.CompressPubkey(pubKey)
 	pubKeyHex := hex.EncodeToString(pubKeyBytes)
 	keyID.ID = keyPath(identity, ls.keyType, pubKeyHex)
@@ -119,7 +120,7 @@ func (ls *localStorageEthKeyProvider) LinkToIdentity(ctx context.Context, keyID 
 
 // ListByIdentity lists keys by identity
 func (ls *localStorageEthKeyProvider) ListByIdentity(ctx context.Context, identity w3c.DID) ([]KeyID, error) {
-	return ls.localStorageFileManager.searchByIdentityInFile(ctx, identity)
+	return ls.localStorageFileManager.searchByIdentityInFile(ctx, identity, ls.keyType)
 }
 
 // nolint

--- a/internal/kms/local_storage_utils.go
+++ b/internal/kms/local_storage_utils.go
@@ -1,0 +1,135 @@
+package kms
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/iden3/go-iden3-core/v2/w3c"
+
+	"github.com/polygonid/sh-id-platform/internal/log"
+)
+
+// LocalStorageFileManager - interface for managing local storage
+type LocalStorageFileManager interface {
+	saveKeyMaterialToFile(ctx context.Context, keyMaterial map[string]string, id string) error
+	searchByIdentityInFile(ctx context.Context, identity w3c.DID) ([]KeyID, error)
+	searchKeyMaterialInFileAndReplace(ctx context.Context, id string, identity w3c.DID) error
+	searchPrivateKeyInFile(ctx context.Context, keyID KeyID) (string, error)
+}
+
+type localStorageFileManager struct {
+	file string
+}
+
+// NewLocalStorageFileManager - creates new local storage file manager
+func NewLocalStorageFileManager(file string) LocalStorageFileManager {
+	return &localStorageFileManager{file}
+}
+
+func (ls *localStorageFileManager) saveKeyMaterialToFile(ctx context.Context, keyMaterial map[string]string, id string) error {
+	localStorageFileContent, err := readContentFile(ctx, ls.file)
+	if err != nil {
+		return err
+	}
+
+	localStorageFileContent = append(localStorageFileContent, localStorageBJJKeyProviderFileContent{
+		KeyPath:    id,
+		KeyType:    keyMaterial[jsonKeyType],
+		PrivateKey: keyMaterial[jsonKeyData],
+	})
+
+	newFileContent, err := json.Marshal(localStorageFileContent)
+	if err != nil {
+		log.Error(ctx, "cannot marshal file content", "err", err)
+		return err
+	}
+	// nolint: all
+	if err := os.WriteFile(ls.file, newFileContent, 0644); err != nil {
+		log.Error(ctx, "cannot write file", "err", err)
+		return err
+	}
+	return nil
+}
+
+func (ls *localStorageFileManager) searchByIdentityInFile(ctx context.Context, identity w3c.DID) ([]KeyID, error) {
+	localStorageFileContent, err := readContentFile(ctx, ls.file)
+	if err != nil {
+		return nil, err
+	}
+
+	keyIDs := make([]KeyID, 0)
+	for _, keyMaterial := range localStorageFileContent {
+		keyParts := strings.Split(keyMaterial.KeyPath, "/")
+		if len(keyParts) != partsNumber {
+			continue
+		}
+		if keyParts[0] == identity.String() {
+			keyIDs = append(keyIDs, KeyID{
+				Type: KeyType(keyMaterial.KeyType),
+				ID:   keyMaterial.KeyPath,
+			})
+		}
+	}
+	return keyIDs, nil
+}
+
+func (ls *localStorageFileManager) searchKeyMaterialInFileAndReplace(ctx context.Context, id string, identity w3c.DID) error {
+	localStorageFileContent, err := readContentFile(ctx, ls.file)
+	if err != nil {
+		return err
+	}
+
+	for i, keyMaterial := range localStorageFileContent {
+		if keyMaterial.KeyPath == id {
+			keyMaterial.KeyPath = identity.String() + "/" + keyMaterial.KeyPath
+			localStorageFileContent[i] = keyMaterial
+			newFileContent, err := json.Marshal(localStorageFileContent)
+			if err != nil {
+				log.Error(ctx, "cannot marshal file content", "err", err)
+				return err
+			}
+			// nolint: all
+			if err := os.WriteFile(ls.file, newFileContent, 0644); err != nil {
+				log.Error(ctx, "cannot write file", "err", err)
+				return err
+			}
+			return nil
+		}
+	}
+
+	return errors.New("key not found")
+}
+
+func (ls *localStorageFileManager) searchPrivateKeyInFile(ctx context.Context, keyID KeyID) (string, error) {
+	localStorageFileContent, err := readContentFile(ctx, ls.file)
+	if err != nil {
+		return "", err
+	}
+
+	for _, keyMaterial := range localStorageFileContent {
+		if keyMaterial.KeyPath == keyID.ID {
+			return keyMaterial.PrivateKey, nil
+		}
+	}
+
+	return "", errors.New("key not found")
+}
+
+func readContentFile(ctx context.Context, file string) ([]localStorageBJJKeyProviderFileContent, error) {
+	fileContent, err := os.ReadFile(file)
+	if err != nil {
+		log.Error(ctx, "cannot read file", "err", err, "file", file)
+		return nil, err
+	}
+
+	var localStorageFileContent []localStorageBJJKeyProviderFileContent
+	if err := json.Unmarshal(fileContent, &localStorageFileContent); err != nil {
+		log.Error(ctx, "cannot unmarshal file content", "err", err)
+		return nil, err
+	}
+
+	return localStorageFileContent, nil
+}

--- a/internal/kms/local_storage_utils_test.go
+++ b/internal/kms/local_storage_utils_test.go
@@ -1,0 +1,171 @@
+package kms
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/iden3/go-iden3-core/v2/w3c"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveKeyMaterialToFile_Success(t *testing.T) {
+	tmpFile, err := createTestFile(t)
+	assert.NoError(t, err)
+	//nolint:errcheck
+	defer os.Remove(tmpFile.Name())
+
+	ls := NewLocalStorageFileManager(tmpFile.Name())
+	ctx := context.Background()
+	keyMaterial := map[string]string{jsonKeyType: "Ethereum", jsonKeyData: "0xABC123"}
+	id := "key1"
+
+	err = ls.saveKeyMaterialToFile(ctx, keyMaterial, id)
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(tmpFile.Name())
+	require.NoError(t, err)
+
+	var fileContent []localStorageBJJKeyProviderFileContent
+	err = json.Unmarshal(content, &fileContent)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, len(fileContent))
+	assert.Equal(t, id, fileContent[0].KeyPath)
+	assert.Equal(t, keyMaterial[jsonKeyType], fileContent[0].KeyType)
+	assert.Equal(t, keyMaterial[jsonKeyData], fileContent[0].PrivateKey)
+}
+
+func TestSaveKeyMaterialToFile_FailOnFileWrite(t *testing.T) {
+	ls := NewLocalStorageFileManager("/path/to/non/existent/file")
+	ctx := context.Background()
+	keyMaterial := map[string]string{"type": "Ethereum", "data": "0xABC123"}
+	id := "key1"
+
+	err := ls.saveKeyMaterialToFile(ctx, keyMaterial, id)
+	assert.Error(t, err)
+}
+
+func TestSearchByIdentityInFile_ReturnsKeyIDsOnMatch(t *testing.T) {
+	tmpFile, err := createTestFile(t)
+	assert.NoError(t, err)
+	//nolint:errcheck
+	defer os.Remove(tmpFile.Name())
+
+	identity := "did:polygonid:polygon:amoy:2qQ68JkRcf3ybQNvgRV9BP6qLgBrXmUezqBi4wsEuV"
+	fileContent := []localStorageBJJKeyProviderFileContent{
+		{KeyPath: identity + "/key1", KeyType: "ETH", PrivateKey: "0xABC123"},
+		{KeyPath: "did:example:456/key2", KeyType: "Bitcoin", PrivateKey: "0xDEF456"},
+	}
+
+	content, err := json.Marshal(fileContent)
+	require.NoError(t, err)
+	//nolint:all
+	err = os.WriteFile("./kms.json", content, 0644)
+	require.NoError(t, err)
+
+	ls := NewLocalStorageFileManager(tmpFile.Name())
+	ctx := context.Background()
+	did, err := w3c.ParseDID(identity)
+	require.NoError(t, err)
+	keyIDs, err := ls.searchByIdentityInFile(ctx, *did)
+	require.NoError(t, err)
+	require.Len(t, keyIDs, 1)
+	assert.Equal(t, KeyID{Type: KeyType("ETH"), ID: identity + "/key1"}, keyIDs[0])
+}
+
+//nolint:lll
+func TestSearchByIdentityInFile_ReturnsErrorOnFileReadFailure(t *testing.T) {
+	ls := NewLocalStorageFileManager("/path/to/nonexistent/file")
+	ctx := context.Background()
+	did, err := w3c.ParseDID("did:polygonid:polygon:amoy:2qQ68JkRcf3ybQNvgRV9BP6qLgBrXmUezqBi4wsEuV")
+	require.NoError(t, err)
+	_, err = ls.searchByIdentityInFile(ctx, *did)
+	assert.Error(t, err)
+}
+
+func TestSearchByIdentityInFile_ReturnsEmptySliceWhenNoMatch(t *testing.T) {
+	tmpFile, err := createTestFile(t)
+	assert.NoError(t, err)
+	//nolint:errcheck
+	defer os.Remove(tmpFile.Name())
+
+	fileContent := []localStorageBJJKeyProviderFileContent{
+		{KeyPath: "did:example:456/key1", KeyType: "ETH", PrivateKey: "0xABC123"},
+	}
+	content, err := json.Marshal(fileContent)
+	require.NoError(t, err)
+	//nolint:all
+	err = os.WriteFile("./kms.json", content, 0644)
+	require.NoError(t, err)
+
+	ls := NewLocalStorageFileManager(tmpFile.Name())
+	ctx := context.Background()
+
+	did, err := w3c.ParseDID("did:polygonid:polygon:amoy:2qQ68JkRcf3ybQNvgRV9BP6qLgBrXmUezqBi4wsEuV")
+	require.NoError(t, err)
+
+	keyIDs, err := ls.searchByIdentityInFile(ctx, *did)
+	require.NoError(t, err)
+	assert.Empty(t, keyIDs)
+}
+
+//nolint:lll
+func TestSearchPrivateKeyInFile_ReturnsPrivateKeyOnMatch(t *testing.T) {
+	tmpFile, err := createTestFile(t)
+	assert.NoError(t, err)
+	//nolint:errcheck
+	defer os.Remove(tmpFile.Name())
+
+	fileContent := []localStorageBJJKeyProviderFileContent{
+		{KeyPath: "key1", KeyType: "ETH", PrivateKey: "0xABC123"},
+	}
+	content, err := json.Marshal(fileContent)
+	require.NoError(t, err)
+	//nolint:all
+	err = os.WriteFile("./kms.json", content, 0644)
+	require.NoError(t, err)
+
+	ls := NewLocalStorageFileManager(tmpFile.Name())
+	ctx := context.Background()
+
+	privateKey, err := ls.searchPrivateKeyInFile(ctx, KeyID{ID: "key1"})
+	require.NoError(t, err)
+	assert.Equal(t, "0xABC123", privateKey)
+}
+
+//nolint:lll
+func TestSearchPrivateKeyInFile_ReturnsErrorWhenKeyNotFound(t *testing.T) {
+	tmpFile, err := createTestFile(t)
+	assert.NoError(t, err)
+	//nolint:errcheck
+	defer os.Remove(tmpFile.Name())
+
+	fileContent := []localStorageBJJKeyProviderFileContent{
+		{KeyPath: "key1", KeyType: "Ethereum", PrivateKey: "0xABC123"},
+	}
+	content, err := json.Marshal(fileContent)
+	require.NoError(t, err)
+	//nolint:all
+	err = os.WriteFile("./kms.json", content, 0644)
+	require.NoError(t, err)
+
+	ls := NewLocalStorageFileManager(tmpFile.Name())
+	ctx := context.Background()
+
+	_, err = ls.searchPrivateKeyInFile(ctx, KeyID{ID: "key2"})
+	assert.Error(t, err)
+}
+
+func createTestFile(t *testing.T) (*os.File, error) {
+	t.Helper()
+	tmpFile, err := os.Create("./kms.json")
+	assert.NoError(t, err)
+	initFileContent := []byte("[]")
+	_, err = tmpFile.Write(initFileContent)
+	assert.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+	return tmpFile, err
+}

--- a/internal/kms/local_storage_utils_test.go
+++ b/internal/kms/local_storage_utils_test.go
@@ -56,8 +56,8 @@ func TestSearchByIdentityInFile_ReturnsKeyIDsOnMatch(t *testing.T) {
 
 	identity := "did:polygonid:polygon:amoy:2qQ68JkRcf3ybQNvgRV9BP6qLgBrXmUezqBi4wsEuV"
 	fileContent := []localStorageBJJKeyProviderFileContent{
-		{KeyPath: identity + "/key1", KeyType: "ETH", PrivateKey: "0xABC123"},
-		{KeyPath: "did:example:456/key2", KeyType: "Bitcoin", PrivateKey: "0xDEF456"},
+		{KeyPath: identity + "/ETH:0347fe70a2a9b752e8012d72851c35a13a1423bcdac4bde6ec036e1ea9317b36ac", KeyType: string(KeyTypeEthereum), PrivateKey: "0xABC123"},
+		{KeyPath: "keys/" + identity + "/BJJ:cecf34ed27074e121f1e8a8cc75954ab2b28506258b87b3c9a20e33461f4b12a", KeyType: string(KeyTypeBabyJubJub), PrivateKey: "0xDEF456"},
 	}
 
 	content, err := json.Marshal(fileContent)
@@ -70,10 +70,16 @@ func TestSearchByIdentityInFile_ReturnsKeyIDsOnMatch(t *testing.T) {
 	ctx := context.Background()
 	did, err := w3c.ParseDID(identity)
 	require.NoError(t, err)
-	keyIDs, err := ls.searchByIdentityInFile(ctx, *did)
+
+	keyIDs, err := ls.searchByIdentityInFile(ctx, *did, KeyTypeEthereum)
 	require.NoError(t, err)
 	require.Len(t, keyIDs, 1)
-	assert.Equal(t, KeyID{Type: KeyType("ETH"), ID: identity + "/key1"}, keyIDs[0])
+	assert.Equal(t, KeyID{Type: KeyTypeEthereum, ID: identity + "/ETH:0347fe70a2a9b752e8012d72851c35a13a1423bcdac4bde6ec036e1ea9317b36ac"}, keyIDs[0])
+
+	keyIDs, err = ls.searchByIdentityInFile(ctx, *did, KeyTypeBabyJubJub)
+	require.NoError(t, err)
+	require.Len(t, keyIDs, 1)
+	assert.Equal(t, KeyID{Type: KeyTypeBabyJubJub, ID: "keys/" + identity + "/BJJ:cecf34ed27074e121f1e8a8cc75954ab2b28506258b87b3c9a20e33461f4b12a"}, keyIDs[0])
 }
 
 //nolint:lll
@@ -82,7 +88,7 @@ func TestSearchByIdentityInFile_ReturnsErrorOnFileReadFailure(t *testing.T) {
 	ctx := context.Background()
 	did, err := w3c.ParseDID("did:polygonid:polygon:amoy:2qQ68JkRcf3ybQNvgRV9BP6qLgBrXmUezqBi4wsEuV")
 	require.NoError(t, err)
-	_, err = ls.searchByIdentityInFile(ctx, *did)
+	_, err = ls.searchByIdentityInFile(ctx, *did, KeyTypeEthereum)
 	assert.Error(t, err)
 }
 
@@ -93,7 +99,7 @@ func TestSearchByIdentityInFile_ReturnsEmptySliceWhenNoMatch(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 
 	fileContent := []localStorageBJJKeyProviderFileContent{
-		{KeyPath: "did:example:456/key1", KeyType: "ETH", PrivateKey: "0xABC123"},
+		{KeyPath: "key/did:example:456", KeyType: string(KeyTypeEthereum), PrivateKey: "0xABC123"},
 	}
 	content, err := json.Marshal(fileContent)
 	require.NoError(t, err)
@@ -107,7 +113,7 @@ func TestSearchByIdentityInFile_ReturnsEmptySliceWhenNoMatch(t *testing.T) {
 	did, err := w3c.ParseDID("did:polygonid:polygon:amoy:2qQ68JkRcf3ybQNvgRV9BP6qLgBrXmUezqBi4wsEuV")
 	require.NoError(t, err)
 
-	keyIDs, err := ls.searchByIdentityInFile(ctx, *did)
+	keyIDs, err := ls.searchByIdentityInFile(ctx, *did, KeyTypeEthereum)
 	require.NoError(t, err)
 	assert.Empty(t, keyIDs)
 }

--- a/internal/kms/vault_bjj_key_provider.go
+++ b/internal/kms/vault_bjj_key_provider.go
@@ -21,11 +21,6 @@ type vaultBJJKeyProvider struct {
 	reAnonKeyPathHex *regexp.Regexp // RE of key path not bounded to identity
 }
 
-const (
-	defaultLength = 32
-	partsNumber   = 2
-)
-
 // NewVaultBJJKeyProvider creates new key provider for BabyJubJub keys stored
 // in vault
 func NewVaultBJJKeyProvider(vaultCli *api.Client, keyType KeyType) KeyProvider {

--- a/internal/kms/vault_eth_key_provider.go
+++ b/internal/kms/vault_eth_key_provider.go
@@ -203,10 +203,3 @@ func DecodeETHPubKey(key []byte) (*ecdsa.PublicKey, error) {
 	pubKey, err := crypto.DecompressPubkey(key)
 	return pubKey, errors.WithStack(err)
 }
-
-// decodeETHPrivateKey is a helper method to convert byte representation of
-// private key to *ecdsa.PrivateKey
-func decodeETHPrivateKey(key []byte) (*ecdsa.PrivateKey, error) {
-	privKey, err := crypto.ToECDSA(key)
-	return privKey, errors.WithStack(err)
-}

--- a/internal/kms/vault_providers_helpers.go
+++ b/internal/kms/vault_providers_helpers.go
@@ -1,9 +1,11 @@
 package kms
 
 import (
+	"crypto/ecdsa"
 	"fmt"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/hashicorp/vault/api"
 	"github.com/iden3/go-iden3-core/v2/w3c"
 	"github.com/pkg/errors"
@@ -14,8 +16,12 @@ const keysPathPrefix = "keys/"
 const kvStoragePath = "secret"
 
 const (
-	jsonKeyType = "key_type"
-	jsonKeyData = "key_data"
+	jsonKeyType   = "key_type"
+	jsonKeyData   = "key_data"
+	defaultLength = 32
+	partsNumber   = 2
+	// LocalStorageFileName is the name of the file where the keys are stored
+	LocalStorageFileName = "kms_localstorage_keys.json"
 )
 
 func saveKeyMaterial(vaultCli *api.Client, path string, jsonObj map[string]string) error {
@@ -113,4 +119,11 @@ func moveSecretData(vaultCli *api.Client, oldPath, newPath string) error {
 
 	_, err = cli.Delete(absVaultSecretPath(oldPath))
 	return errors.WithStack(err)
+}
+
+// decodeETHPrivateKey is a helper method to convert byte representation of
+// private key to *ecdsa.PrivateKey
+func decodeETHPrivateKey(key []byte) (*ecdsa.PrivateKey, error) {
+	privKey, err := crypto.ToECDSA(key)
+	return privKey, errors.WithStack(err)
 }


### PR DESCRIPTION
### Notes
Now the issuer node can be run without using the vault, saving the private keys in a file, which is useful for local and/or testing environments.
* The`ISSUER_KMS_PLUGIN` environment variable allows you to specify the type of storage for private keys. Accepts the values ​​"localstorage" and "vault.
* Added a new command in the make file to run the infrastructure (postgres and redis) without vault: `make up/localstorage`
* To add the private key to the localstorage a new command was added: `make private_key=4b3XXX add-private-key-localstorage`