### PR TITLE
feat: Rename claims endpoints to credential endpoints

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,8 +1,6 @@
 name: golangci-lint
-on:
-  push:
-    branches:
-      - "*"
+
+on: [push]
 
 permissions:
   contents: read

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -8,8 +8,8 @@ info:
 tags:
   - name: Identity
     description: Collection of endpoints related to Identity
-  - name: Claim
-    description: Collection of endpoints related to Claims
+  - name: Credentials
+    description: Collection of endpoints related to Credentials
   - name: Agent
     description: Collection of endpoints related to Mobile
 
@@ -202,15 +202,108 @@ paths:
           $ref: '#/components/responses/500'
 
 
+  #credentials:
+  /v1/{identifier}/credentials:
+    post:
+      summary: Create Credential
+      operationId: CreateCredential
+      description: Endpoint to create a Credential
+      tags:
+        - Credentials
+      security:
+        - basicAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/pathIdentifier'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateClaimRequest'
+      responses:
+        '201':
+          description: Credential Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateClaimResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '422':
+          $ref: '#/components/responses/422'
+        '500':
+          $ref: '#/components/responses/500'
+    get:
+      summary: Get Credentials
+      operationId: GetCredentials
+      description: |
+        Endpoint to retrieve Credentials 
+        > ⚠️ **self** and **subject** filter cannot be used together
+      tags:
+        - Claim
+      security:
+        - basicAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/pathIdentifier'
+        - in: query
+          name: schemaType
+          schema:
+            type: string
+          description: Filter per schema type. Example - KYCAgeCredential
+        - in: query
+          name: schemaHash
+          schema:
+            type: string
+          description: Filter per schema hash. Example - c9b2370371b7fa8b3dab2a5ba81b6838
+        - in: query
+          name: subject
+          schema:
+            type: string
+          description: Filter per subject. Example - did:polygonid:polygon:amoy:2qE1BZ7gcmEoP2KppvFPCZqyzyb5tK9T6Gec5HFANQ
+        - in: query
+          name: revoked
+          schema:
+            type: boolean
+          description: Filter per credentials revoked or not - Example - true.
+        - in: query
+          name: self
+          schema:
+            type: boolean
+          description: Filter per retrieve credentials of the provided identifier. Example - true
+        - in: query
+          name: query_field
+          schema:
+            type: string
+          description: Filter this field inside the data of the claim
+        - in: query
+          name: query_value
+          schema:
+            type: string
+          description: Filter this value inside the data of the claim for the specified field in query_field
+      responses:
+        '200':
+          description: Credentials found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetClaimsResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '500':
+          $ref: '#/components/responses/500'
 
   #claims:
   /v1/{identifier}/claims:
     post:
-      summary: Create Claim
+      summary: Create Claim (Deprecated)
       operationId: CreateClaim
-      description: Endpoint to create a Claim
+      description: Endpoint to create a Claim. Deprecated, use /v1/{identifier}/credentials instead
       tags:
-        - Claim
+        - Credentials
       security:
         - basicAuth: [ ]
       parameters:
@@ -237,13 +330,13 @@ paths:
         '500':
           $ref: '#/components/responses/500'
     get:
-      summary: Get Claims
+      summary: Get Claims (Deprecated)
       operationId: GetClaims
       description: |
-        Endpoint to retrieve claims 
+        Endpoint to retrieve claims. Deprecated, use /v1/{identifier}/credentials instead
         > ⚠️ **self** and **subject** filter cannot be used together
       tags:
-        - Claim
+        - Credentials
       security:
         - basicAuth: [ ]
       parameters:
@@ -296,13 +389,43 @@ paths:
           $ref: '#/components/responses/401'
         '500':
           $ref: '#/components/responses/500'
+
+
+  /v1/{identifier}/credentials/{id}:
+    get:
+      summary: Get Claim
+      operationId: GetCredential
+      description: Endpoint to retrieve a created Credential
+      tags:
+        - Credentials
+      security:
+        - basicAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/pathIdentifier'
+        - $ref: '#/components/parameters/pathClaim'
+      responses:
+        '200':
+          description: Credential found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetClaimResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
+
   /v1/{identifier}/claims/{id}:
     get:
       summary: Get Claim
       operationId: GetClaim
       description: Endpoint to retrieve a created Claim
       tags:
-        - Claim
+        - Credentials
       security:
         - basicAuth: [ ]
       parameters:
@@ -323,13 +446,14 @@ paths:
           $ref: '#/components/responses/404'
         '500':
           $ref: '#/components/responses/500'
-  /v1/{identifier}/claims/revoke/{nonce}:
+
+  /v1/{identifier}/credentials/revoke/{nonce}:
     post:
-      summary: Revoke Claim
-      operationId: RevokeClaim
-      description: Endpoint to revoke a claim
+      summary: Revoke Credential
+      operationId: RevokeCredential
+      description: Endpoint to revoke a credential
       tags:
-        - Claim
+        - Credentials
       security:
         - basicAuth: [ ]
       parameters:
@@ -350,13 +474,43 @@ paths:
           $ref: '#/components/responses/404'
         '500':
           $ref: '#/components/responses/500'
-  /v1/{identifier}/claims/revocation/status/{nonce}:
+
+
+  /v1/{identifier}/claims/revoke/{nonce}:
+    post:
+      summary: Revoke Claim (Deprecated)
+      operationId: RevokeClaim
+      description: Endpoint to revoke a claim. DEPRECATED, use /v1/{identifier}/credentials/revoke/{nonce} instead
+      tags:
+        - Credentials
+      security:
+        - basicAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/pathIdentifier'
+        - $ref: '#/components/parameters/pathNonce'
+      responses:
+        '202':
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RevokeClaimResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
+
+  /v1/{identifier}/credentials/revocation/status/{nonce}:
     get:
       summary: Get Revocation Status
-      operationId: GetRevocationStatus
+      operationId: GetRevocationStatusV2
       description: Endpoint to get the revocation status
       tags:
-        - Claim
+        - Credentials
       parameters:
         - $ref: '#/components/parameters/pathIdentifier'
         - $ref: '#/components/parameters/pathNonce'
@@ -371,11 +525,62 @@ paths:
           $ref: '#/components/responses/400'
         '500':
           $ref: '#/components/responses/500'
+
+  /v1/{identifier}/claims/revocation/status/{nonce}:
+    get:
+      summary: Get Revocation Status (Deprecated)
+      operationId: GetRevocationStatus
+      description: Endpoint to get the revocation status. DEPRECATED use /v1/{identifier}/credentials/revocation/status/{nonce} instead
+      tags:
+        - Credentials
+      parameters:
+        - $ref: '#/components/parameters/pathIdentifier'
+        - $ref: '#/components/parameters/pathNonce'
+      responses:
+        '200':
+          description: Proof
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RevocationStatusResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '500':
+          $ref: '#/components/responses/500'
+
+  /v1/{identifier}/credentials/{id}/qrcode:
+    get:
+      summary: Get Credentials QR code
+      operationId: GetCredentialQrCode
+      description: Returns a a json that can be used to create the QR Code to scan for accepting a claim.
+      tags:
+        - Claim
+      security:
+        - basicAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/pathIdentifier'
+        - $ref: '#/components/parameters/pathClaim'
+      responses:
+        '200':
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetClaimQrCodeResponse'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+        '409':
+          $ref: '#/components/responses/409'
+        '500':
+          $ref: '#/components/responses/500'
+
   /v1/{identifier}/claims/{id}/qrcode:
     get:
-      summary: Get Claim QR code
+      summary: Get Claim QR code (Deprecated)
       operationId: GetClaimQrCode
-      description: Returns a a json that can be used to create the QR Code to scan for accepting a claim.
+      description: Returns a a json that can be used to create the QR Code to scan for accepting a claim. DEPRECATED use /v1/{identifier}/credentials/{id}/qrcode instead
       tags:
         - Claim
       security:

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -59,6 +59,7 @@ type Config = []KeyValue
 
 // CreateClaimRequest defines model for CreateClaimRequest.
 type CreateClaimRequest struct {
+	ClaimID               *uuid.UUID                  `json:"claimID"`
 	CredentialSchema      string                      `json:"credentialSchema"`
 	CredentialSubject     map[string]interface{}      `json:"credentialSubject"`
 	DisplayMethod         *DisplayMethod              `json:"displayMethod,omitempty"`

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -303,6 +303,30 @@ type GetClaimsParams struct {
 	QueryValue *string `form:"query_value,omitempty" json:"query_value,omitempty"`
 }
 
+// GetCredentialsParams defines parameters for GetCredentials.
+type GetCredentialsParams struct {
+	// SchemaType Filter per schema type. Example - KYCAgeCredential
+	SchemaType *string `form:"schemaType,omitempty" json:"schemaType,omitempty"`
+
+	// SchemaHash Filter per schema hash. Example - c9b2370371b7fa8b3dab2a5ba81b6838
+	SchemaHash *string `form:"schemaHash,omitempty" json:"schemaHash,omitempty"`
+
+	// Subject Filter per subject. Example - did:polygonid:polygon:amoy:2qE1BZ7gcmEoP2KppvFPCZqyzyb5tK9T6Gec5HFANQ
+	Subject *string `form:"subject,omitempty" json:"subject,omitempty"`
+
+	// Revoked Filter per credentials revoked or not - Example - true.
+	Revoked *bool `form:"revoked,omitempty" json:"revoked,omitempty"`
+
+	// Self Filter per retrieve credentials of the provided identifier. Example - true
+	Self *bool `form:"self,omitempty" json:"self,omitempty"`
+
+	// QueryField Filter this field inside the data of the claim
+	QueryField *string `form:"query_field,omitempty" json:"query_field,omitempty"`
+
+	// QueryValue Filter this value inside the data of the claim for the specified field in query_field
+	QueryValue *string `form:"query_value,omitempty" json:"query_value,omitempty"`
+}
+
 // AgentTextRequestBody defines body for Agent for text/plain ContentType.
 type AgentTextRequestBody = AgentTextBody
 
@@ -312,18 +336,21 @@ type CreateIdentityJSONRequestBody = CreateIdentityRequest
 // CreateClaimJSONRequestBody defines body for CreateClaim for application/json ContentType.
 type CreateClaimJSONRequestBody = CreateClaimRequest
 
+// CreateCredentialJSONRequestBody defines body for CreateCredential for application/json ContentType.
+type CreateCredentialJSONRequestBody = CreateClaimRequest
+
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
-	// GetEthClient the documentation
+	// Get the documentation
 	// (GET /)
 	GetDocumentation(w http.ResponseWriter, r *http.Request)
-	// GetEthClient Config
+	// Get Config
 	// (GET /config)
 	GetConfig(w http.ResponseWriter, r *http.Request)
 	// Gets the favicon
 	// (GET /favicon.ico)
 	GetFavicon(w http.ResponseWriter, r *http.Request)
-	// GetEthClient the documentation yaml file
+	// Get the documentation yaml file
 	// (GET /static/docs/api/api.yaml)
 	GetYaml(w http.ResponseWriter, r *http.Request)
 	// Healthcheck
@@ -332,7 +359,7 @@ type ServerInterface interface {
 	// Agent
 	// (POST /v1/agent)
 	Agent(w http.ResponseWriter, r *http.Request)
-	// GetEthClient Identities
+	// Get Identities
 	// (GET /v1/identities)
 	GetIdentities(w http.ResponseWriter, r *http.Request)
 	// Create Identity
@@ -344,24 +371,42 @@ type ServerInterface interface {
 	// QrCode body
 	// (GET /v1/qr-store)
 	GetQrFromStore(w http.ResponseWriter, r *http.Request, params GetQrFromStoreParams)
-	// GetEthClient Claims
+	// Get Claims (Deprecated)
 	// (GET /v1/{identifier}/claims)
 	GetClaims(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, params GetClaimsParams)
-	// Create Claim
+	// Create Claim (Deprecated)
 	// (POST /v1/{identifier}/claims)
 	CreateClaim(w http.ResponseWriter, r *http.Request, identifier PathIdentifier)
-	// GetEthClient Revocation Status
+	// Get Revocation Status (Deprecated)
 	// (GET /v1/{identifier}/claims/revocation/status/{nonce})
 	GetRevocationStatus(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, nonce PathNonce)
-	// Revoke Claim
+	// Revoke Claim (Deprecated)
 	// (POST /v1/{identifier}/claims/revoke/{nonce})
 	RevokeClaim(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, nonce PathNonce)
-	// GetEthClient Claim
+	// Get Claim
 	// (GET /v1/{identifier}/claims/{id})
 	GetClaim(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, id PathClaim)
-	// GetEthClient Claim QR code
+	// Get Claim QR code (Deprecated)
 	// (GET /v1/{identifier}/claims/{id}/qrcode)
 	GetClaimQrCode(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, id PathClaim)
+	// Get Credentials
+	// (GET /v1/{identifier}/credentials)
+	GetCredentials(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, params GetCredentialsParams)
+	// Create Credential
+	// (POST /v1/{identifier}/credentials)
+	CreateCredential(w http.ResponseWriter, r *http.Request, identifier PathIdentifier)
+	// Get Revocation Status
+	// (GET /v1/{identifier}/credentials/revocation/status/{nonce})
+	GetRevocationStatusV2(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, nonce PathNonce)
+	// Revoke Credential
+	// (POST /v1/{identifier}/credentials/revoke/{nonce})
+	RevokeCredential(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, nonce PathNonce)
+	// Get Claim
+	// (GET /v1/{identifier}/credentials/{id})
+	GetCredential(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, id PathClaim)
+	// Get Credentials QR code
+	// (GET /v1/{identifier}/credentials/{id}/qrcode)
+	GetCredentialQrCode(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, id PathClaim)
 	// Publish Identity State
 	// (POST /v1/{identifier}/state/publish)
 	PublishIdentityState(w http.ResponseWriter, r *http.Request, identifier PathIdentifier)
@@ -374,13 +419,13 @@ type ServerInterface interface {
 
 type Unimplemented struct{}
 
-// GetEthClient the documentation
+// Get the documentation
 // (GET /)
 func (_ Unimplemented) GetDocumentation(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
-// GetEthClient Config
+// Get Config
 // (GET /config)
 func (_ Unimplemented) GetConfig(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
@@ -392,7 +437,7 @@ func (_ Unimplemented) GetFavicon(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
-// GetEthClient the documentation yaml file
+// Get the documentation yaml file
 // (GET /static/docs/api/api.yaml)
 func (_ Unimplemented) GetYaml(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
@@ -410,7 +455,7 @@ func (_ Unimplemented) Agent(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
-// GetEthClient Identities
+// Get Identities
 // (GET /v1/identities)
 func (_ Unimplemented) GetIdentities(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNotImplemented)
@@ -434,39 +479,75 @@ func (_ Unimplemented) GetQrFromStore(w http.ResponseWriter, r *http.Request, pa
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
-// GetEthClient Claims
+// Get Claims (Deprecated)
 // (GET /v1/{identifier}/claims)
 func (_ Unimplemented) GetClaims(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, params GetClaimsParams) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
-// Create Claim
+// Create Claim (Deprecated)
 // (POST /v1/{identifier}/claims)
 func (_ Unimplemented) CreateClaim(w http.ResponseWriter, r *http.Request, identifier PathIdentifier) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
-// GetEthClient Revocation Status
+// Get Revocation Status (Deprecated)
 // (GET /v1/{identifier}/claims/revocation/status/{nonce})
 func (_ Unimplemented) GetRevocationStatus(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, nonce PathNonce) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
-// Revoke Claim
+// Revoke Claim (Deprecated)
 // (POST /v1/{identifier}/claims/revoke/{nonce})
 func (_ Unimplemented) RevokeClaim(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, nonce PathNonce) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
-// GetEthClient Claim
+// Get Claim
 // (GET /v1/{identifier}/claims/{id})
 func (_ Unimplemented) GetClaim(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, id PathClaim) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
-// GetEthClient Claim QR code
+// Get Claim QR code (Deprecated)
 // (GET /v1/{identifier}/claims/{id}/qrcode)
 func (_ Unimplemented) GetClaimQrCode(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, id PathClaim) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get Credentials
+// (GET /v1/{identifier}/credentials)
+func (_ Unimplemented) GetCredentials(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, params GetCredentialsParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Create Credential
+// (POST /v1/{identifier}/credentials)
+func (_ Unimplemented) CreateCredential(w http.ResponseWriter, r *http.Request, identifier PathIdentifier) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get Revocation Status
+// (GET /v1/{identifier}/credentials/revocation/status/{nonce})
+func (_ Unimplemented) GetRevocationStatusV2(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, nonce PathNonce) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Revoke Credential
+// (POST /v1/{identifier}/credentials/revoke/{nonce})
+func (_ Unimplemented) RevokeCredential(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, nonce PathNonce) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get Claim
+// (GET /v1/{identifier}/credentials/{id})
+func (_ Unimplemented) GetCredential(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, id PathClaim) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get Credentials QR code
+// (GET /v1/{identifier}/credentials/{id}/qrcode)
+func (_ Unimplemented) GetCredentialQrCode(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, id PathClaim) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -934,6 +1015,267 @@ func (siw *ServerInterfaceWrapper) GetClaimQrCode(w http.ResponseWriter, r *http
 	handler.ServeHTTP(w, r.WithContext(ctx))
 }
 
+// GetCredentials operation middleware
+func (siw *ServerInterfaceWrapper) GetCredentials(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var err error
+
+	// ------------- Path parameter "identifier" -------------
+	var identifier PathIdentifier
+
+	err = runtime.BindStyledParameterWithOptions("simple", "identifier", chi.URLParam(r, "identifier"), &identifier, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "identifier", Err: err})
+		return
+	}
+
+	ctx = context.WithValue(ctx, BasicAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetCredentialsParams
+
+	// ------------- Optional query parameter "schemaType" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "schemaType", r.URL.Query(), &params.SchemaType)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "schemaType", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "schemaHash" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "schemaHash", r.URL.Query(), &params.SchemaHash)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "schemaHash", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "subject" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "subject", r.URL.Query(), &params.Subject)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "subject", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "revoked" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "revoked", r.URL.Query(), &params.Revoked)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "revoked", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "self" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "self", r.URL.Query(), &params.Self)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "self", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "query_field" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "query_field", r.URL.Query(), &params.QueryField)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "query_field", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "query_value" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "query_value", r.URL.Query(), &params.QueryValue)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "query_value", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetCredentials(w, r, identifier, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// CreateCredential operation middleware
+func (siw *ServerInterfaceWrapper) CreateCredential(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var err error
+
+	// ------------- Path parameter "identifier" -------------
+	var identifier PathIdentifier
+
+	err = runtime.BindStyledParameterWithOptions("simple", "identifier", chi.URLParam(r, "identifier"), &identifier, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "identifier", Err: err})
+		return
+	}
+
+	ctx = context.WithValue(ctx, BasicAuthScopes, []string{})
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateCredential(w, r, identifier)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// GetRevocationStatusV2 operation middleware
+func (siw *ServerInterfaceWrapper) GetRevocationStatusV2(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var err error
+
+	// ------------- Path parameter "identifier" -------------
+	var identifier PathIdentifier
+
+	err = runtime.BindStyledParameterWithOptions("simple", "identifier", chi.URLParam(r, "identifier"), &identifier, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "identifier", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "nonce" -------------
+	var nonce PathNonce
+
+	err = runtime.BindStyledParameterWithOptions("simple", "nonce", chi.URLParam(r, "nonce"), &nonce, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "nonce", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetRevocationStatusV2(w, r, identifier, nonce)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// RevokeCredential operation middleware
+func (siw *ServerInterfaceWrapper) RevokeCredential(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var err error
+
+	// ------------- Path parameter "identifier" -------------
+	var identifier PathIdentifier
+
+	err = runtime.BindStyledParameterWithOptions("simple", "identifier", chi.URLParam(r, "identifier"), &identifier, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "identifier", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "nonce" -------------
+	var nonce PathNonce
+
+	err = runtime.BindStyledParameterWithOptions("simple", "nonce", chi.URLParam(r, "nonce"), &nonce, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "nonce", Err: err})
+		return
+	}
+
+	ctx = context.WithValue(ctx, BasicAuthScopes, []string{})
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.RevokeCredential(w, r, identifier, nonce)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// GetCredential operation middleware
+func (siw *ServerInterfaceWrapper) GetCredential(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var err error
+
+	// ------------- Path parameter "identifier" -------------
+	var identifier PathIdentifier
+
+	err = runtime.BindStyledParameterWithOptions("simple", "identifier", chi.URLParam(r, "identifier"), &identifier, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "identifier", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "id" -------------
+	var id PathClaim
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx = context.WithValue(ctx, BasicAuthScopes, []string{})
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetCredential(w, r, identifier, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// GetCredentialQrCode operation middleware
+func (siw *ServerInterfaceWrapper) GetCredentialQrCode(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var err error
+
+	// ------------- Path parameter "identifier" -------------
+	var identifier PathIdentifier
+
+	err = runtime.BindStyledParameterWithOptions("simple", "identifier", chi.URLParam(r, "identifier"), &identifier, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "identifier", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "id" -------------
+	var id PathClaim
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx = context.WithValue(ctx, BasicAuthScopes, []string{})
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetCredentialQrCode(w, r, identifier, id)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
 // PublishIdentityState operation middleware
 func (siw *ServerInterfaceWrapper) PublishIdentityState(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -1150,6 +1492,24 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v1/{identifier}/claims/{id}/qrcode", wrapper.GetClaimQrCode)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v1/{identifier}/credentials", wrapper.GetCredentials)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/v1/{identifier}/credentials", wrapper.CreateCredential)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v1/{identifier}/credentials/revocation/status/{nonce}", wrapper.GetRevocationStatusV2)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/v1/{identifier}/credentials/revoke/{nonce}", wrapper.RevokeCredential)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v1/{identifier}/credentials/{id}", wrapper.GetCredential)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v1/{identifier}/credentials/{id}/qrcode", wrapper.GetCredentialQrCode)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/v1/{identifier}/state/publish", wrapper.PublishIdentityState)
@@ -1783,6 +2143,303 @@ func (response GetClaimQrCode500JSONResponse) VisitGetClaimQrCodeResponse(w http
 	return json.NewEncoder(w).Encode(response)
 }
 
+type GetCredentialsRequestObject struct {
+	Identifier PathIdentifier `json:"identifier"`
+	Params     GetCredentialsParams
+}
+
+type GetCredentialsResponseObject interface {
+	VisitGetCredentialsResponse(w http.ResponseWriter) error
+}
+
+type GetCredentials200JSONResponse GetClaimsResponse
+
+func (response GetCredentials200JSONResponse) VisitGetCredentialsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetCredentials400JSONResponse struct{ N400JSONResponse }
+
+func (response GetCredentials400JSONResponse) VisitGetCredentialsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetCredentials401JSONResponse struct{ N401JSONResponse }
+
+func (response GetCredentials401JSONResponse) VisitGetCredentialsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetCredentials500JSONResponse struct{ N500JSONResponse }
+
+func (response GetCredentials500JSONResponse) VisitGetCredentialsResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateCredentialRequestObject struct {
+	Identifier PathIdentifier `json:"identifier"`
+	Body       *CreateCredentialJSONRequestBody
+}
+
+type CreateCredentialResponseObject interface {
+	VisitCreateCredentialResponse(w http.ResponseWriter) error
+}
+
+type CreateCredential201JSONResponse CreateClaimResponse
+
+func (response CreateCredential201JSONResponse) VisitCreateCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(201)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateCredential400JSONResponse struct{ N400JSONResponse }
+
+func (response CreateCredential400JSONResponse) VisitCreateCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateCredential401JSONResponse struct{ N401JSONResponse }
+
+func (response CreateCredential401JSONResponse) VisitCreateCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateCredential422JSONResponse struct{ N422JSONResponse }
+
+func (response CreateCredential422JSONResponse) VisitCreateCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(422)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type CreateCredential500JSONResponse struct{ N500JSONResponse }
+
+func (response CreateCredential500JSONResponse) VisitCreateCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetRevocationStatusV2RequestObject struct {
+	Identifier PathIdentifier `json:"identifier"`
+	Nonce      PathNonce      `json:"nonce"`
+}
+
+type GetRevocationStatusV2ResponseObject interface {
+	VisitGetRevocationStatusV2Response(w http.ResponseWriter) error
+}
+
+type GetRevocationStatusV2200JSONResponse RevocationStatusResponse
+
+func (response GetRevocationStatusV2200JSONResponse) VisitGetRevocationStatusV2Response(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetRevocationStatusV2400JSONResponse struct{ N400JSONResponse }
+
+func (response GetRevocationStatusV2400JSONResponse) VisitGetRevocationStatusV2Response(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetRevocationStatusV2500JSONResponse struct{ N500JSONResponse }
+
+func (response GetRevocationStatusV2500JSONResponse) VisitGetRevocationStatusV2Response(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type RevokeCredentialRequestObject struct {
+	Identifier PathIdentifier `json:"identifier"`
+	Nonce      PathNonce      `json:"nonce"`
+}
+
+type RevokeCredentialResponseObject interface {
+	VisitRevokeCredentialResponse(w http.ResponseWriter) error
+}
+
+type RevokeCredential202JSONResponse RevokeClaimResponse
+
+func (response RevokeCredential202JSONResponse) VisitRevokeCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(202)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type RevokeCredential400JSONResponse struct{ N400JSONResponse }
+
+func (response RevokeCredential400JSONResponse) VisitRevokeCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type RevokeCredential401JSONResponse struct{ N401JSONResponse }
+
+func (response RevokeCredential401JSONResponse) VisitRevokeCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type RevokeCredential404JSONResponse struct{ N404JSONResponse }
+
+func (response RevokeCredential404JSONResponse) VisitRevokeCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type RevokeCredential500JSONResponse struct{ N500JSONResponse }
+
+func (response RevokeCredential500JSONResponse) VisitRevokeCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetCredentialRequestObject struct {
+	Identifier PathIdentifier `json:"identifier"`
+	Id         PathClaim      `json:"id"`
+}
+
+type GetCredentialResponseObject interface {
+	VisitGetCredentialResponse(w http.ResponseWriter) error
+}
+
+type GetCredential200JSONResponse GetClaimResponse
+
+func (response GetCredential200JSONResponse) VisitGetCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetCredential400JSONResponse struct{ N400JSONResponse }
+
+func (response GetCredential400JSONResponse) VisitGetCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetCredential401JSONResponse struct{ N401JSONResponse }
+
+func (response GetCredential401JSONResponse) VisitGetCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetCredential404JSONResponse struct{ N404JSONResponse }
+
+func (response GetCredential404JSONResponse) VisitGetCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetCredential500JSONResponse struct{ N500JSONResponse }
+
+func (response GetCredential500JSONResponse) VisitGetCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetCredentialQrCodeRequestObject struct {
+	Identifier PathIdentifier `json:"identifier"`
+	Id         PathClaim      `json:"id"`
+}
+
+type GetCredentialQrCodeResponseObject interface {
+	VisitGetCredentialQrCodeResponse(w http.ResponseWriter) error
+}
+
+type GetCredentialQrCode200JSONResponse GetClaimQrCodeResponse
+
+func (response GetCredentialQrCode200JSONResponse) VisitGetCredentialQrCodeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetCredentialQrCode400JSONResponse struct{ N400JSONResponse }
+
+func (response GetCredentialQrCode400JSONResponse) VisitGetCredentialQrCodeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetCredentialQrCode404JSONResponse struct{ N404JSONResponse }
+
+func (response GetCredentialQrCode404JSONResponse) VisitGetCredentialQrCodeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetCredentialQrCode409JSONResponse struct{ N409JSONResponse }
+
+func (response GetCredentialQrCode409JSONResponse) VisitGetCredentialQrCodeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(409)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetCredentialQrCode500JSONResponse struct{ N500JSONResponse }
+
+func (response GetCredentialQrCode500JSONResponse) VisitGetCredentialQrCodeResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type PublishIdentityStateRequestObject struct {
 	Identifier PathIdentifier `json:"identifier"`
 }
@@ -1873,16 +2530,16 @@ func (response RetryPublishState500JSONResponse) VisitRetryPublishStateResponse(
 
 // StrictServerInterface represents all server handlers.
 type StrictServerInterface interface {
-	// GetEthClient the documentation
+	// Get the documentation
 	// (GET /)
 	GetDocumentation(ctx context.Context, request GetDocumentationRequestObject) (GetDocumentationResponseObject, error)
-	// GetEthClient Config
+	// Get Config
 	// (GET /config)
 	GetConfig(ctx context.Context, request GetConfigRequestObject) (GetConfigResponseObject, error)
 	// Gets the favicon
 	// (GET /favicon.ico)
 	GetFavicon(ctx context.Context, request GetFaviconRequestObject) (GetFaviconResponseObject, error)
-	// GetEthClient the documentation yaml file
+	// Get the documentation yaml file
 	// (GET /static/docs/api/api.yaml)
 	GetYaml(ctx context.Context, request GetYamlRequestObject) (GetYamlResponseObject, error)
 	// Healthcheck
@@ -1891,7 +2548,7 @@ type StrictServerInterface interface {
 	// Agent
 	// (POST /v1/agent)
 	Agent(ctx context.Context, request AgentRequestObject) (AgentResponseObject, error)
-	// GetEthClient Identities
+	// Get Identities
 	// (GET /v1/identities)
 	GetIdentities(ctx context.Context, request GetIdentitiesRequestObject) (GetIdentitiesResponseObject, error)
 	// Create Identity
@@ -1903,24 +2560,42 @@ type StrictServerInterface interface {
 	// QrCode body
 	// (GET /v1/qr-store)
 	GetQrFromStore(ctx context.Context, request GetQrFromStoreRequestObject) (GetQrFromStoreResponseObject, error)
-	// GetEthClient Claims
+	// Get Claims (Deprecated)
 	// (GET /v1/{identifier}/claims)
 	GetClaims(ctx context.Context, request GetClaimsRequestObject) (GetClaimsResponseObject, error)
-	// Create Claim
+	// Create Claim (Deprecated)
 	// (POST /v1/{identifier}/claims)
 	CreateClaim(ctx context.Context, request CreateClaimRequestObject) (CreateClaimResponseObject, error)
-	// GetEthClient Revocation Status
+	// Get Revocation Status (Deprecated)
 	// (GET /v1/{identifier}/claims/revocation/status/{nonce})
 	GetRevocationStatus(ctx context.Context, request GetRevocationStatusRequestObject) (GetRevocationStatusResponseObject, error)
-	// Revoke Claim
+	// Revoke Claim (Deprecated)
 	// (POST /v1/{identifier}/claims/revoke/{nonce})
 	RevokeClaim(ctx context.Context, request RevokeClaimRequestObject) (RevokeClaimResponseObject, error)
-	// GetEthClient Claim
+	// Get Claim
 	// (GET /v1/{identifier}/claims/{id})
 	GetClaim(ctx context.Context, request GetClaimRequestObject) (GetClaimResponseObject, error)
-	// GetEthClient Claim QR code
+	// Get Claim QR code (Deprecated)
 	// (GET /v1/{identifier}/claims/{id}/qrcode)
 	GetClaimQrCode(ctx context.Context, request GetClaimQrCodeRequestObject) (GetClaimQrCodeResponseObject, error)
+	// Get Credentials
+	// (GET /v1/{identifier}/credentials)
+	GetCredentials(ctx context.Context, request GetCredentialsRequestObject) (GetCredentialsResponseObject, error)
+	// Create Credential
+	// (POST /v1/{identifier}/credentials)
+	CreateCredential(ctx context.Context, request CreateCredentialRequestObject) (CreateCredentialResponseObject, error)
+	// Get Revocation Status
+	// (GET /v1/{identifier}/credentials/revocation/status/{nonce})
+	GetRevocationStatusV2(ctx context.Context, request GetRevocationStatusV2RequestObject) (GetRevocationStatusV2ResponseObject, error)
+	// Revoke Credential
+	// (POST /v1/{identifier}/credentials/revoke/{nonce})
+	RevokeCredential(ctx context.Context, request RevokeCredentialRequestObject) (RevokeCredentialResponseObject, error)
+	// Get Claim
+	// (GET /v1/{identifier}/credentials/{id})
+	GetCredential(ctx context.Context, request GetCredentialRequestObject) (GetCredentialResponseObject, error)
+	// Get Credentials QR code
+	// (GET /v1/{identifier}/credentials/{id}/qrcode)
+	GetCredentialQrCode(ctx context.Context, request GetCredentialQrCodeRequestObject) (GetCredentialQrCodeResponseObject, error)
 	// Publish Identity State
 	// (POST /v1/{identifier}/state/publish)
 	PublishIdentityState(ctx context.Context, request PublishIdentityStateRequestObject) (PublishIdentityStateResponseObject, error)
@@ -2378,6 +3053,174 @@ func (sh *strictHandler) GetClaimQrCode(w http.ResponseWriter, r *http.Request, 
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(GetClaimQrCodeResponseObject); ok {
 		if err := validResponse.VisitGetClaimQrCodeResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetCredentials operation middleware
+func (sh *strictHandler) GetCredentials(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, params GetCredentialsParams) {
+	var request GetCredentialsRequestObject
+
+	request.Identifier = identifier
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetCredentials(ctx, request.(GetCredentialsRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetCredentials")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetCredentialsResponseObject); ok {
+		if err := validResponse.VisitGetCredentialsResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// CreateCredential operation middleware
+func (sh *strictHandler) CreateCredential(w http.ResponseWriter, r *http.Request, identifier PathIdentifier) {
+	var request CreateCredentialRequestObject
+
+	request.Identifier = identifier
+
+	var body CreateCredentialJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.CreateCredential(ctx, request.(CreateCredentialRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "CreateCredential")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(CreateCredentialResponseObject); ok {
+		if err := validResponse.VisitCreateCredentialResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetRevocationStatusV2 operation middleware
+func (sh *strictHandler) GetRevocationStatusV2(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, nonce PathNonce) {
+	var request GetRevocationStatusV2RequestObject
+
+	request.Identifier = identifier
+	request.Nonce = nonce
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetRevocationStatusV2(ctx, request.(GetRevocationStatusV2RequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetRevocationStatusV2")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetRevocationStatusV2ResponseObject); ok {
+		if err := validResponse.VisitGetRevocationStatusV2Response(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// RevokeCredential operation middleware
+func (sh *strictHandler) RevokeCredential(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, nonce PathNonce) {
+	var request RevokeCredentialRequestObject
+
+	request.Identifier = identifier
+	request.Nonce = nonce
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.RevokeCredential(ctx, request.(RevokeCredentialRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "RevokeCredential")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(RevokeCredentialResponseObject); ok {
+		if err := validResponse.VisitRevokeCredentialResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetCredential operation middleware
+func (sh *strictHandler) GetCredential(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, id PathClaim) {
+	var request GetCredentialRequestObject
+
+	request.Identifier = identifier
+	request.Id = id
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetCredential(ctx, request.(GetCredentialRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetCredential")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetCredentialResponseObject); ok {
+		if err := validResponse.VisitGetCredentialResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// GetCredentialQrCode operation middleware
+func (sh *strictHandler) GetCredentialQrCode(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, id PathClaim) {
+	var request GetCredentialQrCodeRequestObject
+
+	request.Identifier = identifier
+	request.Id = id
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetCredentialQrCode(ctx, request.(GetCredentialQrCodeRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetCredentialQrCode")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetCredentialQrCodeResponseObject); ok {
+		if err := validResponse.VisitGetCredentialQrCodeResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -351,7 +351,7 @@ func TestServer_RevokeClaim(t *testing.T) {
 			expected: expected{
 				httpCode: 202,
 				response: RevokeClaim202JSONResponse{
-					Message: "claim revocation request sent",
+					Message: "credential revocation request sent",
 				},
 			},
 		},
@@ -363,7 +363,7 @@ func TestServer_RevokeClaim(t *testing.T) {
 			expected: expected{
 				httpCode: 404,
 				response: RevokeClaim404JSONResponse{N404JSONResponse{
-					Message: "the claim does not exist",
+					Message: "the credential does not exist",
 				}},
 			},
 		},
@@ -382,7 +382,7 @@ func TestServer_RevokeClaim(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			rr := httptest.NewRecorder()
-			url := fmt.Sprintf("/v1/%s/claims/revoke/%d", tc.did, tc.nonce)
+			url := fmt.Sprintf("/v1/%s/credentials/revoke/%d", tc.did, tc.nonce)
 			req, err := http.NewRequest(http.MethodPost, url, nil)
 			req.SetBasicAuth(tc.auth())
 			require.NoError(t, err)
@@ -393,21 +393,21 @@ func TestServer_RevokeClaim(t *testing.T) {
 			case RevokeClaim202JSONResponse:
 				var response RevokeClaim202JSONResponse
 				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
-				assert.Equal(t, response.Message, v.Message)
+				assert.Equal(t, v.Message, response.Message)
 			case RevokeClaim404JSONResponse:
 				var response RevokeClaim404JSONResponse
 				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
-				assert.Equal(t, response.Message, v.Message)
+				assert.Equal(t, v.Message, response.Message)
 			case RevokeClaim500JSONResponse:
 				var response RevokeClaim500JSONResponse
 				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
-				assert.Equal(t, response.Message, v.Message)
+				assert.Equal(t, v.Message, response.Message)
 			}
 		})
 	}
 }
 
-func TestServer_CreateClaim(t *testing.T) {
+func TestServer_CreateCredential(t *testing.T) {
 	const (
 		method     = "polygonid"
 		blockchain = "polygon"
@@ -451,7 +451,7 @@ func TestServer_CreateClaim(t *testing.T) {
 	did := iden.Identifier
 
 	type expected struct {
-		response                    CreateClaimResponseObject
+		response                    CreateCredentialResponseObject
 		httpCode                    int
 		createCredentialEventsCount int
 	}
@@ -487,7 +487,7 @@ func TestServer_CreateClaim(t *testing.T) {
 				Expiration: common.ToPointer(time.Now().Unix()),
 			},
 			expected: expected{
-				response:                    CreateClaim201JSONResponse{},
+				response:                    CreateCredential201JSONResponse{},
 				httpCode:                    http.StatusCreated,
 				createCredentialEventsCount: 1,
 			},
@@ -511,7 +511,7 @@ func TestServer_CreateClaim(t *testing.T) {
 				},
 			},
 			expected: expected{
-				response:                    CreateClaim201JSONResponse{},
+				response:                    CreateCredential201JSONResponse{},
 				httpCode:                    http.StatusCreated,
 				createCredentialEventsCount: 1,
 			},
@@ -534,7 +534,7 @@ func TestServer_CreateClaim(t *testing.T) {
 				},
 			},
 			expected: expected{
-				response:                    CreateClaim201JSONResponse{},
+				response:                    CreateCredential201JSONResponse{},
 				httpCode:                    http.StatusCreated,
 				createCredentialEventsCount: 1,
 			},
@@ -557,7 +557,7 @@ func TestServer_CreateClaim(t *testing.T) {
 				},
 			},
 			expected: expected{
-				response:                    CreateClaim201JSONResponse{},
+				response:                    CreateCredential201JSONResponse{},
 				httpCode:                    http.StatusCreated,
 				createCredentialEventsCount: 0,
 			},
@@ -576,7 +576,7 @@ func TestServer_CreateClaim(t *testing.T) {
 				Expiration: common.ToPointer(time.Now().Unix()),
 			},
 			expected: expected{
-				response:                    CreateClaim201JSONResponse{},
+				response:                    CreateCredential201JSONResponse{},
 				httpCode:                    http.StatusCreated,
 				createCredentialEventsCount: 1,
 			},
@@ -599,7 +599,7 @@ func TestServer_CreateClaim(t *testing.T) {
 				},
 			},
 			expected: expected{
-				response:                    CreateClaim201JSONResponse{},
+				response:                    CreateCredential201JSONResponse{},
 				httpCode:                    http.StatusCreated,
 				createCredentialEventsCount: 1,
 			},
@@ -619,7 +619,7 @@ func TestServer_CreateClaim(t *testing.T) {
 				Expiration: common.ToPointer(time.Now().Unix()),
 			},
 			expected: expected{
-				response: CreateClaim400JSONResponse{N400JSONResponse{Message: "malformed url"}},
+				response: CreateCredential400JSONResponse{N400JSONResponse{Message: "malformed url"}},
 				httpCode: http.StatusBadRequest,
 			},
 		},
@@ -638,7 +638,7 @@ func TestServer_CreateClaim(t *testing.T) {
 				Expiration: common.ToPointer(time.Now().Unix()),
 			},
 			expected: expected{
-				response: CreateClaim422JSONResponse{N422JSONResponse{Message: "cannot load schema"}},
+				response: CreateCredential422JSONResponse{N422JSONResponse{Message: "cannot load schema"}},
 				httpCode: http.StatusUnprocessableEntity,
 			},
 		},
@@ -658,7 +658,7 @@ func TestServer_CreateClaim(t *testing.T) {
 				Proofs:     &[]CreateClaimRequestProofs{"wrong proof"},
 			},
 			expected: expected{
-				response: CreateClaim400JSONResponse{N400JSONResponse{Message: "unsupported proof type: wrong proof"}},
+				response: CreateCredential400JSONResponse{N400JSONResponse{Message: "unsupported proof type: wrong proof"}},
 				httpCode: http.StatusBadRequest,
 			},
 		},
@@ -666,7 +666,7 @@ func TestServer_CreateClaim(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			pubSub.Clear(event.CreateCredentialEvent)
 			rr := httptest.NewRecorder()
-			url := fmt.Sprintf("/v1/%s/claims", tc.did)
+			url := fmt.Sprintf("/v1/%s/credentials", tc.did)
 
 			req, err := http.NewRequest(http.MethodPost, url, tests.JSONBody(t, tc.body))
 			req.SetBasicAuth(tc.auth())
@@ -783,7 +783,7 @@ func TestServer_GetIdentities(t *testing.T) {
 	}
 }
 
-func TestServer_GetClaimQrCode(t *testing.T) {
+func TestServer_GetCredentialQrCode(t *testing.T) {
 	ctx := context.Background()
 	identityRepo := repositories.NewIdentity()
 	claimsRepo := repositories.NewClaims()
@@ -828,7 +828,7 @@ func TestServer_GetClaimQrCode(t *testing.T) {
 	handler := getHandler(context.Background(), server)
 
 	type expected struct {
-		response GetClaimQrCodeResponseObject
+		response GetCredentialQrCodeResponseObject
 		httpCode int
 	}
 
@@ -855,7 +855,7 @@ func TestServer_GetClaimQrCode(t *testing.T) {
 			did:   idStr,
 			claim: uuid.New(),
 			expected: expected{
-				response: GetClaimQrCode404JSONResponse{N404JSONResponse{
+				response: GetCredentialQrCode404JSONResponse{N404JSONResponse{
 					Message: "claim not found",
 				}},
 				httpCode: http.StatusNotFound,
@@ -867,7 +867,7 @@ func TestServer_GetClaimQrCode(t *testing.T) {
 			did:   idNoClaims,
 			claim: claim.ID,
 			expected: expected{
-				response: GetClaimQrCode404JSONResponse{N404JSONResponse{
+				response: GetCredentialQrCode404JSONResponse{N404JSONResponse{
 					Message: "claim not found",
 				}},
 				httpCode: http.StatusNotFound,
@@ -879,7 +879,7 @@ func TestServer_GetClaimQrCode(t *testing.T) {
 			did:   ":polygon:mumbai:2qPUUYXa98tQWZKSaRidf2QTDyZicFFxkTWNWjk2HJ",
 			claim: claim.ID,
 			expected: expected{
-				response: GetClaimQrCode400JSONResponse{N400JSONResponse{
+				response: GetCredentialQrCode400JSONResponse{N400JSONResponse{
 					Message: "invalid did",
 				}},
 				httpCode: http.StatusBadRequest,
@@ -891,14 +891,14 @@ func TestServer_GetClaimQrCode(t *testing.T) {
 			did:   idStr,
 			claim: claim.ID,
 			expected: expected{
-				response: GetClaimQrCode200JSONResponse{},
+				response: GetCredentialQrCode200JSONResponse{},
 				httpCode: http.StatusOK,
 			},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			rr := httptest.NewRecorder()
-			url := fmt.Sprintf("/v1/%s/claims/%s/qrcode", tc.did, tc.claim)
+			url := fmt.Sprintf("/v1/%s/credentials/%s/qrcode", tc.did, tc.claim)
 			req, err := http.NewRequest("GET", url, nil)
 			req.SetBasicAuth(tc.auth())
 			require.NoError(t, err)
@@ -908,7 +908,7 @@ func TestServer_GetClaimQrCode(t *testing.T) {
 			require.Equal(t, tc.expected.httpCode, rr.Code)
 
 			switch v := tc.expected.response.(type) {
-			case GetClaimQrCode200JSONResponse:
+			case GetCredentialQrCode200JSONResponse:
 				var response GetClaimQrCode200JSONResponse
 				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 				assert.Equal(t, string(protocol.CredentialOfferMessageType), response.Type)
@@ -924,15 +924,15 @@ func TestServer_GetClaimQrCode(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, claim.SchemaType, response.Body.Credentials[0].Description)
 
-			case GetClaimQrCode400JSONResponse:
+			case GetCredentialQrCode400JSONResponse:
 				var response GetClaimQrCode400JSONResponse
 				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 				assert.Equal(t, v.Message, response.Message)
-			case GetClaimQrCode404JSONResponse:
+			case GetCredentialQrCode404JSONResponse:
 				var response GetClaimQrCode400JSONResponse
 				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 				assert.Equal(t, v.Message, response.Message)
-			case GetClaimQrCode500JSONResponse:
+			case GetCredentialQrCode500JSONResponse:
 				var response GetClaimQrCode500JSONResponse
 				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 				assert.Equal(t, v.Message, response.Message)
@@ -941,7 +941,7 @@ func TestServer_GetClaimQrCode(t *testing.T) {
 	}
 }
 
-func TestServer_GetClaim(t *testing.T) {
+func TestServer_GetCredential(t *testing.T) {
 	ctx := context.Background()
 	identityRepo := repositories.NewIdentity()
 	claimsRepo := repositories.NewClaims()
@@ -996,7 +996,7 @@ func TestServer_GetClaim(t *testing.T) {
 	handler := getHandler(context.Background(), server)
 
 	type expected struct {
-		response GetClaimResponseObject
+		response GetCredentialResponseObject
 		httpCode int
 	}
 
@@ -1024,7 +1024,7 @@ func TestServer_GetClaim(t *testing.T) {
 			claimID: uuid.New(),
 			expected: expected{
 				httpCode: http.StatusNotFound,
-				response: GetClaim404JSONResponse{N404JSONResponse{
+				response: GetCredential404JSONResponse{N404JSONResponse{
 					Message: "claim not found",
 				}},
 			},
@@ -1036,7 +1036,7 @@ func TestServer_GetClaim(t *testing.T) {
 			claimID: claim.ID,
 			expected: expected{
 				httpCode: http.StatusNotFound,
-				response: GetClaim404JSONResponse{N404JSONResponse{
+				response: GetCredential404JSONResponse{N404JSONResponse{
 					Message: "claim not found",
 				}},
 			},
@@ -1048,7 +1048,7 @@ func TestServer_GetClaim(t *testing.T) {
 			claimID: claim.ID,
 			expected: expected{
 				httpCode: http.StatusBadRequest,
-				response: GetClaim400JSONResponse{N400JSONResponse{
+				response: GetCredential400JSONResponse{N400JSONResponse{
 					Message: "invalid did",
 				}},
 			},
@@ -1060,14 +1060,14 @@ func TestServer_GetClaim(t *testing.T) {
 			claimID: claim.ID,
 			expected: expected{
 				httpCode: http.StatusOK,
-				response: GetClaim200JSONResponse{
+				response: GetCredential200JSONResponse{
 					Context: []string{"https://www.w3.org/2018/credentials/v1", "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/iden3credential-v2.json-ld", "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/kyc-v3.json-ld"},
 					CredentialSchema: CredentialSchema{
 						"https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json/KYCAgeCredential-v3.json",
 						"JsonSchemaValidator2018",
 					},
 					CredentialStatus: verifiable.CredentialStatus{
-						ID:              fmt.Sprintf("http://localhost/v1/%s/claims/revocation/status/%d", idStr, claim.RevNonce),
+						ID:              fmt.Sprintf("http://localhost/v1/%s/credentials/revocation/status/%d", idStr, claim.RevNonce),
 						Type:            "SparseMerkleTreeProof",
 						RevocationNonce: uint64(claim.RevNonce),
 					},
@@ -1077,7 +1077,7 @@ func TestServer_GetClaim(t *testing.T) {
 						"documentType": float64(2),
 						"type":         "KYCAgeCredential",
 					},
-					Id:           fmt.Sprintf("http://localhost/api/v1/claim/%s", claim.ID),
+					Id:           fmt.Sprintf("http://localhost/api/v1/credentials/%s", claim.ID),
 					IssuanceDate: common.ToPointer(TimeUTC(time.Now())),
 					Issuer:       idStr,
 					Type:         []string{"VerifiableCredential", "KYCAgeCredential"},
@@ -1091,7 +1091,7 @@ func TestServer_GetClaim(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			rr := httptest.NewRecorder()
-			url := fmt.Sprintf("/v1/%s/claims/%s", tc.did, tc.claimID.String())
+			url := fmt.Sprintf("/v1/%s/credentials/%s", tc.did, tc.claimID.String())
 			req, err := http.NewRequest("GET", url, nil)
 			req.SetBasicAuth(tc.auth())
 			require.NoError(t, err)
@@ -1101,20 +1101,20 @@ func TestServer_GetClaim(t *testing.T) {
 			require.Equal(t, tc.expected.httpCode, rr.Code)
 
 			switch v := tc.expected.response.(type) {
-			case GetClaim200JSONResponse:
+			case GetCredential200JSONResponse:
 				var response GetClaimResponse
 				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 				validateClaim(t, response, GetClaimResponse(v))
 
-			case GetClaim400JSONResponse:
+			case GetCredential400JSONResponse:
 				var response GetClaim404JSONResponse
 				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 				assert.Equal(t, response.Message, v.Message)
-			case GetClaim404JSONResponse:
+			case GetCredential404JSONResponse:
 				var response GetClaim404JSONResponse
 				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 				assert.Equal(t, response.Message, v.Message)
-			case GetClaim500JSONResponse:
+			case GetCredential500JSONResponse:
 				var response GetClaim500JSONResponse
 				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 				assert.Equal(t, response.Message, v.Message)
@@ -1123,7 +1123,7 @@ func TestServer_GetClaim(t *testing.T) {
 	}
 }
 
-func TestServer_GetClaims(t *testing.T) {
+func TestServer_GetCredentials(t *testing.T) {
 	const (
 		method     = "polygonid"
 		blockchain = "polygon"
@@ -1171,7 +1171,7 @@ func TestServer_GetClaims(t *testing.T) {
 	handler := getHandler(context.Background(), server)
 
 	type expected struct {
-		response GetClaimsResponseObject
+		response GetCredentialsResponseObject
 		len      int
 		httpCode int
 	}
@@ -1208,7 +1208,7 @@ func TestServer_GetClaims(t *testing.T) {
 			did:  ":polygon:mumbai:2qPUUYXa98tQWZKSaRidf2QTDyZicFFxkTWNWjk2HJ",
 			expected: expected{
 				httpCode: http.StatusBadRequest,
-				response: GetClaims400JSONResponse{N400JSONResponse{
+				response: GetCredentials400JSONResponse{N400JSONResponse{
 					Message: "invalid did",
 				}},
 			},
@@ -1223,7 +1223,7 @@ func TestServer_GetClaims(t *testing.T) {
 			},
 			expected: expected{
 				httpCode: http.StatusBadRequest,
-				response: GetClaims400JSONResponse{N400JSONResponse{"self and subject filter cannot be used together"}},
+				response: GetCredentials400JSONResponse{N400JSONResponse{"self and subject filter cannot be used together"}},
 			},
 		},
 		{
@@ -1233,7 +1233,7 @@ func TestServer_GetClaims(t *testing.T) {
 			expected: expected{
 				httpCode: http.StatusOK,
 				len:      0,
-				response: GetClaims200JSONResponse{},
+				response: GetCredentials200JSONResponse{},
 			},
 		},
 		{
@@ -1243,7 +1243,7 @@ func TestServer_GetClaims(t *testing.T) {
 			expected: expected{
 				httpCode: http.StatusOK,
 				len:      1,
-				response: GetClaims200JSONResponse{
+				response: GetCredentials200JSONResponse{
 					GetClaimResponse{
 						Context: []string{"https://www.w3.org/2018/credentials/v1", "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/iden3credential-v2.json-ld", "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/kyc-v3.json-ld"},
 						CredentialSchema: CredentialSchema{
@@ -1251,7 +1251,7 @@ func TestServer_GetClaims(t *testing.T) {
 							"JsonSchemaValidator2018",
 						},
 						CredentialStatus: verifiable.CredentialStatus{
-							ID:              fmt.Sprintf("http://localhost/v1/%s/claims/revocation/status/%d", identityMultipleClaims.Identifier, claim.RevNonce),
+							ID:              fmt.Sprintf("http://localhost/v1/%s/credentials/revocation/status/%d", identityMultipleClaims.Identifier, claim.RevNonce),
 							Type:            "SparseMerkleTreeProof",
 							RevocationNonce: uint64(claim.RevNonce),
 						},
@@ -1261,7 +1261,7 @@ func TestServer_GetClaims(t *testing.T) {
 							"documentType": float64(2),
 							"type":         "KYCAgeCredential",
 						},
-						Id:           fmt.Sprintf("http://localhost/api/v1/claim/%s", claim.ID),
+						Id:           fmt.Sprintf("http://localhost/api/v1/credentials/%s", claim.ID),
 						IssuanceDate: common.ToPointer(TimeUTC(time.Now())),
 						Issuer:       identityMultipleClaims.Identifier,
 						Type:         []string{"VerifiableCredential", "KYCAgeCredential"},
@@ -1283,7 +1283,7 @@ func TestServer_GetClaims(t *testing.T) {
 			expected: expected{
 				httpCode: http.StatusOK,
 				len:      1,
-				response: GetClaims200JSONResponse{
+				response: GetCredentials200JSONResponse{
 					GetClaimResponse{
 						Context: []string{"https://www.w3.org/2018/credentials/v1", "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/iden3credential-v2.json-ld", "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/kyc-v3.json-ld"},
 						CredentialSchema: CredentialSchema{
@@ -1291,7 +1291,7 @@ func TestServer_GetClaims(t *testing.T) {
 							"JsonSchemaValidator2018",
 						},
 						CredentialStatus: verifiable.CredentialStatus{
-							ID:              fmt.Sprintf("http://localhost/v1/%s/claims/revocation/status/%d", identityMultipleClaims.Identifier, claim.RevNonce),
+							ID:              fmt.Sprintf("http://localhost/v1/%s/credentials/revocation/status/%d", identityMultipleClaims.Identifier, claim.RevNonce),
 							Type:            "SparseMerkleTreeProof",
 							RevocationNonce: uint64(claim.RevNonce),
 						},
@@ -1301,7 +1301,7 @@ func TestServer_GetClaims(t *testing.T) {
 							"documentType": float64(2),
 							"type":         "KYCAgeCredential",
 						},
-						Id:           fmt.Sprintf("http://localhost/api/v1/claim/%s", claim.ID),
+						Id:           fmt.Sprintf("http://localhost/api/v1/credentials/%s", claim.ID),
 						IssuanceDate: common.ToPointer(TimeUTC(time.Now())),
 						Issuer:       identityMultipleClaims.Identifier,
 						Type:         []string{"VerifiableCredential", "KYCAgeCredential"},
@@ -1324,7 +1324,7 @@ func TestServer_GetClaims(t *testing.T) {
 			expected: expected{
 				httpCode: http.StatusOK,
 				len:      1,
-				response: GetClaims200JSONResponse{
+				response: GetCredentials200JSONResponse{
 					GetClaimResponse{
 						Context: []string{"https://www.w3.org/2018/credentials/v1", "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/iden3credential-v2.json-ld", "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/kyc-v3.json-ld"},
 						CredentialSchema: CredentialSchema{
@@ -1332,7 +1332,7 @@ func TestServer_GetClaims(t *testing.T) {
 							"JsonSchemaValidator2018",
 						},
 						CredentialStatus: verifiable.CredentialStatus{
-							ID:              fmt.Sprintf("http://localhost/v1/%s/claims/revocation/status/%d", identityMultipleClaims.Identifier, claim.RevNonce),
+							ID:              fmt.Sprintf("http://localhost/v1/%s/credentials/revocation/status/%d", identityMultipleClaims.Identifier, claim.RevNonce),
 							Type:            "SparseMerkleTreeProof",
 							RevocationNonce: uint64(claim.RevNonce),
 						},
@@ -1342,7 +1342,7 @@ func TestServer_GetClaims(t *testing.T) {
 							"documentType": float64(2),
 							"type":         "KYCAgeCredential",
 						},
-						Id:           fmt.Sprintf("http://localhost/api/v1/claim/%s", claim.ID),
+						Id:           fmt.Sprintf("http://localhost/api/v1/credentials/%s", claim.ID),
 						IssuanceDate: common.ToPointer(TimeUTC(time.Now())),
 						Issuer:       identityMultipleClaims.Identifier,
 						Type:         []string{"VerifiableCredential", "KYCAgeCredential"},
@@ -1364,7 +1364,7 @@ func TestServer_GetClaims(t *testing.T) {
 			expected: expected{
 				httpCode: http.StatusOK,
 				len:      0,
-				response: GetClaims200JSONResponse{},
+				response: GetCredentials200JSONResponse{},
 			},
 		},
 		{
@@ -1377,7 +1377,7 @@ func TestServer_GetClaims(t *testing.T) {
 			expected: expected{
 				httpCode: http.StatusOK,
 				len:      1,
-				response: GetClaims200JSONResponse{
+				response: GetCredentials200JSONResponse{
 					GetClaimResponse{
 						Context: []string{"https://www.w3.org/2018/credentials/v1", "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/iden3credential-v2.json-ld", "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/kyc-v3.json-ld"},
 						CredentialSchema: CredentialSchema{
@@ -1385,7 +1385,7 @@ func TestServer_GetClaims(t *testing.T) {
 							"JsonSchemaValidator2018",
 						},
 						CredentialStatus: verifiable.CredentialStatus{
-							ID:              fmt.Sprintf("http://localhost/v1/%s/claims/revocation/status/%d", identityMultipleClaims.Identifier, claim.RevNonce),
+							ID:              fmt.Sprintf("http://localhost/v1/%s/credentials/revocation/status/%d", identityMultipleClaims.Identifier, claim.RevNonce),
 							Type:            "SparseMerkleTreeProof",
 							RevocationNonce: uint64(claim.RevNonce),
 						},
@@ -1395,7 +1395,7 @@ func TestServer_GetClaims(t *testing.T) {
 							"documentType": float64(2),
 							"type":         "KYCAgeCredential",
 						},
-						Id:           fmt.Sprintf("http://localhost/api/v1/claim/%s", claim.ID),
+						Id:           fmt.Sprintf("http://localhost/api/v1/credentials/%s", claim.ID),
 						IssuanceDate: common.ToPointer(TimeUTC(time.Now())),
 						Issuer:       identityMultipleClaims.Identifier,
 						Type:         []string{"VerifiableCredential", "KYCAgeCredential"},
@@ -1417,7 +1417,7 @@ func TestServer_GetClaims(t *testing.T) {
 			expected: expected{
 				httpCode: http.StatusOK,
 				len:      1,
-				response: GetClaims200JSONResponse{
+				response: GetCredentials200JSONResponse{
 					GetClaimResponse{
 						Context: []string{"https://www.w3.org/2018/credentials/v1", "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/iden3credential-v2.json-ld", "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/kyc-v3.json-ld"},
 						CredentialSchema: CredentialSchema{
@@ -1425,7 +1425,7 @@ func TestServer_GetClaims(t *testing.T) {
 							"JsonSchemaValidator2018",
 						},
 						CredentialStatus: verifiable.CredentialStatus{
-							ID:              fmt.Sprintf("http://localhost/v1/%s/claims/revocation/status/%d", identityMultipleClaims.Identifier, claim.RevNonce),
+							ID:              fmt.Sprintf("http://localhost/v1/%s/credentials/revocation/status/%d", identityMultipleClaims.Identifier, claim.RevNonce),
 							Type:            "SparseMerkleTreeProof",
 							RevocationNonce: uint64(claim.RevNonce),
 						},
@@ -1435,7 +1435,7 @@ func TestServer_GetClaims(t *testing.T) {
 							"documentType": float64(2),
 							"type":         "KYCAgeCredential",
 						},
-						Id:           fmt.Sprintf("http://localhost/api/v1/claim/%s", claim.ID),
+						Id:           fmt.Sprintf("http://localhost/api/v1/credentials/%s", claim.ID),
 						IssuanceDate: common.ToPointer(TimeUTC(time.Now())),
 						Issuer:       identityMultipleClaims.Identifier,
 						Type:         []string{"VerifiableCredential", "KYCAgeCredential"},
@@ -1460,18 +1460,18 @@ func TestServer_GetClaims(t *testing.T) {
 			require.Equal(t, tc.expected.httpCode, rr.Code)
 
 			switch v := tc.expected.response.(type) {
-			case GetClaims200JSONResponse:
+			case GetCredentials200JSONResponse:
 				var response GetClaims200JSONResponse
 				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 				assert.Equal(t, tc.expected.len, len(response))
 				for i := range response {
 					validateClaim(t, response[i], v[i])
 				}
-			case GetClaims400JSONResponse:
+			case GetCredentials400JSONResponse:
 				var response GetClaims400JSONResponse
 				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 				assert.Equal(t, response.Message, v.Message)
-			case GetClaims500JSONResponse:
+			case GetCredentials500JSONResponse:
 				var response GetClaims500JSONResponse
 				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 				assert.Equal(t, response.Message, v.Message)
@@ -1569,7 +1569,7 @@ func TestServer_GetRevocationStatus(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			rr := httptest.NewRecorder()
-			url := fmt.Sprintf("/v1/%s/claims/revocation/status/%d", identity.Identifier, tc.nonce)
+			url := fmt.Sprintf("/v1/%s/credentials/revocation/status/%d", identity.Identifier, tc.nonce)
 			req, err := http.NewRequest("GET", url, nil)
 			req.SetBasicAuth(tc.auth())
 			require.NoError(t, err)
@@ -1641,7 +1641,7 @@ func validateClaim(t *testing.T, resp, tc GetClaimResponse) {
 }
 
 func createGetClaimsURL(did string, schemaHash *string, schemaType *string, subject *string, revoked *string, self *string, queryField *string) string {
-	tURL := &url.URL{Path: fmt.Sprintf("/v1/%s/claims", did)}
+	tURL := &url.URL{Path: fmt.Sprintf("/v1/%s/credentials", did)}
 	q := tURL.Query()
 
 	if self != nil {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -627,7 +627,7 @@ func TestServer_CreateCredential(t *testing.T) {
 				},
 			},
 			expected: expected{
-				response: CreateClaim201JSONResponse{
+				response: CreateCredential201JSONResponse{
 					Id: claimID.String(),
 				},
 				httpCode:                    http.StatusCreated,

--- a/internal/core/services/identity.go
+++ b/internal/core/services/identity.go
@@ -1098,7 +1098,7 @@ func (i *identity) authClaimToModel(ctx context.Context, did *w3c.DID, identity 
 		return nil, err
 	}
 
-	authCred.ID = fmt.Sprintf("%s/api/v1/claim/%s", strings.TrimSuffix(hostURL, "/"), authClaimID)
+	authCred.ID = fmt.Sprintf("%s/api/v1/credentials/%s", strings.TrimSuffix(hostURL, "/"), authClaimID)
 	cs, err := i.revocationStatusResolver.GetCredentialRevocationStatus(ctx, *did, revNonce, *identity.State.State, status)
 	if err != nil {
 		log.Error(ctx, "get credential status", "err", err)

--- a/internal/db/tests/claims_fixture.go
+++ b/internal/db/tests/claims_fixture.go
@@ -75,7 +75,7 @@ func (f *Fixture) NewClaim(t *testing.T, identity string) *domain.Claim {
 	}
 
 	vc := verifiable.W3CCredential{
-		ID:           fmt.Sprintf("http://localhost/api/v1/claim/%s", claimID),
+		ID:           fmt.Sprintf("http://localhost/api/v1/credentials/%s", claimID),
 		Context:      []string{"https://www.w3.org/2018/credentials/v1", "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/iden3credential-v2.json-ld", "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json-ld/kyc-v3.json-ld"},
 		Type:         []string{"VerifiableCredential", "KYCAgeCredential"},
 		IssuanceDate: common.ToPointer(time.Now().UTC()),
@@ -86,7 +86,7 @@ func (f *Fixture) NewClaim(t *testing.T, identity string) *domain.Claim {
 			"type":         "KYCAgeCredential",
 		},
 		CredentialStatus: verifiable.CredentialStatus{
-			ID:              fmt.Sprintf("http://localhost/v1/%s/claims/revocation/status/%d", identity, revNonce),
+			ID:              fmt.Sprintf("http://localhost/v1/%s/credentials/revocation/status/%d", identity, revNonce),
 			Type:            "SparseMerkleTreeProof",
 			RevocationNonce: uint64(revNonce),
 		},


### PR DESCRIPTION
This PR duplicate old "claims" endpoints in core API renaming it to "credentials". Old claims endpoints remains untouched but marked as deprecated.