### PR TITLE
feat: add paginated credentials, delete credential endpoinst, PATCH method to CORS

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,7 +14,7 @@ jobs:
           touch .env-issuer
           touch .env-ui
       - name: Docker Compose
-        uses: isbang/compose-action@v1.4.1 # Needs actions/checkout before
+        uses: hoverkraft-tech/compose-action@v2.0.1
         with:
           compose-file: './infrastructure/local/docker-compose-infra.yml'
           services: |

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -635,6 +635,83 @@ paths:
         '500':
           $ref: '#/components/responses/500'
 
+  /v1/{identifier}/credentials/page/{page}:
+    get:
+      summary: Get Credentials Paginated
+      operationId: GetCredentialsPaginated
+      description: |
+        Return all the credentials for page.
+        Filter between all | revoked | expired credentials and also perform a full text search with the query parameter.
+      tags:
+        - Credentials
+      security:
+        - basicAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/pathIdentifier'
+        - in: path
+          name: page
+          schema:
+            type: integer
+            format: uint
+            minimum: 1
+            example: 1
+          description: Page to fetch. First is one.
+        - in: query
+          name: did
+          schema:
+            type: string
+            example: did:polygonid:polygon:amoy:2qFpPHotk6oyaX1fcrpQFT4BMnmg8YszUwxYtaoGoe
+        - in: query
+          name: status
+          schema:
+            type: string
+            enum: [ all, revoked, expired ]
+          description: >
+            Schema type:
+              * `all` - All Schemas. (default value)
+              * `revoked` - Only revoked schemas
+              * `expired` - Only expired schemas
+        - in: query
+          name: query
+          schema:
+            type: string
+          description: Query string to do full text search
+        - in: query
+          name: max_results
+          schema:
+            type: integer
+            format: uint
+            example: 50
+            default: 50
+          description: Number of items to fetch on each page. Minimum is 10. Default is 50. No maximum by the moment.
+        - in: query
+          name: sort
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum: [ "schemaType", "-schemaType", "createdAt", "-createdAt", "expiresAt", "-expiresAt", "revoked", "-revoked" ]
+              default: "-createdAt"
+
+            description: >
+              The minus sign (-) before createdAt means descending order.
+
+      responses:
+        '200':
+          description: List of credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CredentialsPaginated'
+        '400':
+          $ref: '#/components/responses/400'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
+
   /v1/{identifier}/claims:
     post:
       summary: Create Claim (Deprecated)
@@ -754,6 +831,30 @@ paths:
           $ref: '#/components/responses/401'
         '404':
           $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
+    delete:
+      summary: Delete Credential
+      operationId: DeleteCredential
+      description: Endpoint to delete a Credential
+      tags:
+        - Credentials
+      security:
+        - basicAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/pathIdentifier'
+        - $ref: '#/components/parameters/pathClaim'
+      responses:
+        '200':
+          description: Claim deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericMessage'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
         '500':
           $ref: '#/components/responses/500'
 
@@ -1973,6 +2074,17 @@ components:
         type:
           type: string
           x-omitempty: false
+      
+    CredentialsPaginated:
+      type: object
+      required: [ items, meta ]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Credential'
+        meta:
+          $ref: '#/components/schemas/PaginatedMetadata'
 
     RevokeClaimResponse:
       type: object

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -211,7 +211,7 @@ paths:
                 type: array
                 x-omitempty: false
                 items:
-                  type: string
+                  $ref: '#/components/schemas/GetIdentitiesResponse'
         '401':
           $ref: '#/components/responses/401'
         '500':
@@ -1641,6 +1641,36 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/GetConnectionResponse'
+
+    GetIdentitiesResponse:
+      type: object
+      required:
+        - identifier
+        - method
+        - blockchain
+        - network
+      properties:
+        identifier:
+          type: string
+          x-omitempty: false
+          example: did:polygonid:polygon:amoy:2qMZrfBsXuGFTwSqkqYki78zF3pe1vtXoqH4yRLsfs
+        authBJJCredentialStatus:
+          type: string
+          x-omitempty: true
+          example: "Iden3ReverseSparseMerkleTreeProof"
+          enum: [ Iden3commRevocationStatusV1.0, Iden3ReverseSparseMerkleTreeProof, Iden3OnchainSparseMerkleTreeProof2023 ]
+        method:
+          type: string
+          x-omitempty: false
+          example: "polygonid"
+        blockchain:
+          type: string
+          x-omitempty: false
+          example: "polygon"
+        network:
+          type: string
+          x-omitempty: false
+          example: "amoy"
 
     GetConnectionResponse:
       type: object

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -635,7 +635,7 @@ paths:
         '500':
           $ref: '#/components/responses/500'
 
-  /v1/{identifier}/credentials/page/{page}:
+  /v1/{identifier}/credentials/search:
     get:
       summary: Get Credentials Paginated
       operationId: GetCredentialsPaginated
@@ -648,14 +648,14 @@ paths:
         - basicAuth: [ ]
       parameters:
         - $ref: '#/components/parameters/pathIdentifier'
-        - in: path
+        - in: query
           name: page
           schema:
             type: integer
             format: uint
             minimum: 1
             example: 1
-          description: Page to fetch. First is one.
+          description: Page to fetch. First is one. If omitted, all results will be returned.
         - in: query
           name: did
           schema:

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -667,10 +667,10 @@ paths:
             type: string
             enum: [ all, revoked, expired ]
           description: >
-            Schema type:
-              * `all` - All Schemas. (default value)
-              * `revoked` - Only revoked schemas
-              * `expired` - Only expired schemas
+            Credential status:
+              * `all` - All Credentials. (default value)
+              * `revoked` - Only revoked credentials
+              * `expired` - Only expired credentials
         - in: query
           name: query
           schema:

--- a/cmd/platform/main.go
+++ b/cmd/platform/main.go
@@ -178,7 +178,7 @@ func main() {
 
 	corsMiddleware := cors.New(cors.Options{
 		AllowedOrigins:   []string{"localhost", "127.0.0.1", "*"},
-		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"},
 		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type"},
 		AllowCredentials: true,
 	})

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -81,10 +81,10 @@ const (
 
 // Defines values for GetConnectionsParamsSort.
 const (
-	CreatedAt      GetConnectionsParamsSort = "createdAt"
-	MinusCreatedAt GetConnectionsParamsSort = "-createdAt"
-	MinusUserID    GetConnectionsParamsSort = "-userID"
-	UserID         GetConnectionsParamsSort = "userID"
+	GetConnectionsParamsSortCreatedAt      GetConnectionsParamsSort = "createdAt"
+	GetConnectionsParamsSortMinusCreatedAt GetConnectionsParamsSort = "-createdAt"
+	GetConnectionsParamsSortMinusUserID    GetConnectionsParamsSort = "-userID"
+	GetConnectionsParamsSortUserID         GetConnectionsParamsSort = "userID"
 )
 
 // Defines values for GetLinksParamsStatus.
@@ -93,6 +93,25 @@ const (
 	GetLinksParamsStatusAll      GetLinksParamsStatus = "all"
 	GetLinksParamsStatusExceeded GetLinksParamsStatus = "exceeded"
 	GetLinksParamsStatusInactive GetLinksParamsStatus = "inactive"
+)
+
+// Defines values for GetCredentialsPaginatedParamsStatus.
+const (
+	All     GetCredentialsPaginatedParamsStatus = "all"
+	Expired GetCredentialsPaginatedParamsStatus = "expired"
+	Revoked GetCredentialsPaginatedParamsStatus = "revoked"
+)
+
+// Defines values for GetCredentialsPaginatedParamsSort.
+const (
+	GetCredentialsPaginatedParamsSortCreatedAt       GetCredentialsPaginatedParamsSort = "createdAt"
+	GetCredentialsPaginatedParamsSortExpiresAt       GetCredentialsPaginatedParamsSort = "expiresAt"
+	GetCredentialsPaginatedParamsSortMinusCreatedAt  GetCredentialsPaginatedParamsSort = "-createdAt"
+	GetCredentialsPaginatedParamsSortMinusExpiresAt  GetCredentialsPaginatedParamsSort = "-expiresAt"
+	GetCredentialsPaginatedParamsSortMinusRevoked    GetCredentialsPaginatedParamsSort = "-revoked"
+	GetCredentialsPaginatedParamsSortMinusSchemaType GetCredentialsPaginatedParamsSort = "-schemaType"
+	GetCredentialsPaginatedParamsSortRevoked         GetCredentialsPaginatedParamsSort = "revoked"
+	GetCredentialsPaginatedParamsSortSchemaType      GetCredentialsPaginatedParamsSort = "schemaType"
 )
 
 // AgentResponse defines model for AgentResponse.
@@ -231,6 +250,12 @@ type CredentialSchema struct {
 
 // CredentialSubject defines model for CredentialSubject.
 type CredentialSubject = map[string]interface{}
+
+// CredentialsPaginated defines model for CredentialsPaginated.
+type CredentialsPaginated struct {
+	Items []Credential      `json:"items"`
+	Meta  PaginatedMetadata `json:"meta"`
+}
 
 // DisplayMethod defines model for DisplayMethod.
 type DisplayMethod struct {
@@ -684,6 +709,30 @@ type GetLinkQRCodeParams struct {
 	SessionID SessionID `form:"sessionID" json:"sessionID"`
 }
 
+// GetCredentialsPaginatedParams defines parameters for GetCredentialsPaginated.
+type GetCredentialsPaginatedParams struct {
+	Did *string `form:"did,omitempty" json:"did,omitempty"`
+
+	// Status Schema type:
+	//   * `all` - All Schemas. (default value)
+	//   * `revoked` - Only revoked schemas
+	//   * `expired` - Only expired schemas
+	Status *GetCredentialsPaginatedParamsStatus `form:"status,omitempty" json:"status,omitempty"`
+
+	// Query Query string to do full text search
+	Query *string `form:"query,omitempty" json:"query,omitempty"`
+
+	// MaxResults Number of items to fetch on each page. Minimum is 10. Default is 50. No maximum by the moment.
+	MaxResults *uint                                `form:"max_results,omitempty" json:"max_results,omitempty"`
+	Sort       *[]GetCredentialsPaginatedParamsSort `form:"sort,omitempty" json:"sort,omitempty"`
+}
+
+// GetCredentialsPaginatedParamsStatus defines parameters for GetCredentialsPaginated.
+type GetCredentialsPaginatedParamsStatus string
+
+// GetCredentialsPaginatedParamsSort defines parameters for GetCredentialsPaginated.
+type GetCredentialsPaginatedParamsSort string
+
 // GetSchemasParams defines parameters for GetSchemas.
 type GetSchemasParams struct {
 	// Query Query string to do full text search in schema types and attributes.
@@ -827,12 +876,18 @@ type ServerInterface interface {
 	// Create Authentication Link QRCode
 	// (POST /v1/{identifier}/credentials/links/{id}/qrcode)
 	CreateLinkQrCode(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, id Id)
+	// Get Credentials Paginated
+	// (GET /v1/{identifier}/credentials/page/{page})
+	GetCredentialsPaginated(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, page uint, params GetCredentialsPaginatedParams)
 	// Get Revocation Status
 	// (GET /v1/{identifier}/credentials/revocation/status/{nonce})
 	GetRevocationStatusV2(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, nonce PathNonce)
 	// Revoke Credential
 	// (POST /v1/{identifier}/credentials/revoke/{nonce})
 	RevokeCredential(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, nonce PathNonce)
+	// Delete Credential
+	// (DELETE /v1/{identifier}/credentials/{id})
+	DeleteCredential(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, id PathClaim)
 	// Get Claim
 	// (GET /v1/{identifier}/credentials/{id})
 	GetCredential(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, id PathClaim)
@@ -1076,6 +1131,12 @@ func (_ Unimplemented) CreateLinkQrCode(w http.ResponseWriter, r *http.Request, 
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+// Get Credentials Paginated
+// (GET /v1/{identifier}/credentials/page/{page})
+func (_ Unimplemented) GetCredentialsPaginated(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, page uint, params GetCredentialsPaginatedParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // Get Revocation Status
 // (GET /v1/{identifier}/credentials/revocation/status/{nonce})
 func (_ Unimplemented) GetRevocationStatusV2(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, nonce PathNonce) {
@@ -1085,6 +1146,12 @@ func (_ Unimplemented) GetRevocationStatusV2(w http.ResponseWriter, r *http.Requ
 // Revoke Credential
 // (POST /v1/{identifier}/credentials/revoke/{nonce})
 func (_ Unimplemented) RevokeCredential(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, nonce PathNonce) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Delete Credential
+// (DELETE /v1/{identifier}/credentials/{id})
+func (_ Unimplemented) DeleteCredential(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, id PathClaim) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -2407,6 +2474,86 @@ func (siw *ServerInterfaceWrapper) CreateLinkQrCode(w http.ResponseWriter, r *ht
 	handler.ServeHTTP(w, r.WithContext(ctx))
 }
 
+// GetCredentialsPaginated operation middleware
+func (siw *ServerInterfaceWrapper) GetCredentialsPaginated(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var err error
+
+	// ------------- Path parameter "identifier" -------------
+	var identifier PathIdentifier
+
+	err = runtime.BindStyledParameterWithOptions("simple", "identifier", chi.URLParam(r, "identifier"), &identifier, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "identifier", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "page" -------------
+	var page uint
+
+	err = runtime.BindStyledParameterWithOptions("simple", "page", chi.URLParam(r, "page"), &page, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: false})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "page", Err: err})
+		return
+	}
+
+	ctx = context.WithValue(ctx, BasicAuthScopes, []string{})
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params GetCredentialsPaginatedParams
+
+	// ------------- Optional query parameter "did" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "did", r.URL.Query(), &params.Did)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "did", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "status" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "status", r.URL.Query(), &params.Status)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "status", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "query" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "query", r.URL.Query(), &params.Query)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "query", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "max_results" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "max_results", r.URL.Query(), &params.MaxResults)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "max_results", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "sort" -------------
+
+	err = runtime.BindQueryParameter("form", false, false, "sort", r.URL.Query(), &params.Sort)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "sort", Err: err})
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetCredentialsPaginated(w, r, identifier, page, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
 // GetRevocationStatusV2 operation middleware
 func (siw *ServerInterfaceWrapper) GetRevocationStatusV2(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
@@ -2470,6 +2617,43 @@ func (siw *ServerInterfaceWrapper) RevokeCredential(w http.ResponseWriter, r *ht
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.RevokeCredential(w, r, identifier, nonce)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// DeleteCredential operation middleware
+func (siw *ServerInterfaceWrapper) DeleteCredential(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var err error
+
+	// ------------- Path parameter "identifier" -------------
+	var identifier PathIdentifier
+
+	err = runtime.BindStyledParameterWithOptions("simple", "identifier", chi.URLParam(r, "identifier"), &identifier, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "identifier", Err: err})
+		return
+	}
+
+	// ------------- Path parameter "id" -------------
+	var id PathClaim
+
+	err = runtime.BindStyledParameterWithOptions("simple", "id", chi.URLParam(r, "id"), &id, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "id", Err: err})
+		return
+	}
+
+	ctx = context.WithValue(ctx, BasicAuthScopes, []string{})
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.DeleteCredential(w, r, identifier, id)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2988,10 +3172,16 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Post(options.BaseURL+"/v1/{identifier}/credentials/links/{id}/qrcode", wrapper.CreateLinkQrCode)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/v1/{identifier}/credentials/page/{page}", wrapper.GetCredentialsPaginated)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v1/{identifier}/credentials/revocation/status/{nonce}", wrapper.GetRevocationStatusV2)
 	})
 	r.Group(func(r chi.Router) {
 		r.Post(options.BaseURL+"/v1/{identifier}/credentials/revoke/{nonce}", wrapper.RevokeCredential)
+	})
+	r.Group(func(r chi.Router) {
+		r.Delete(options.BaseURL+"/v1/{identifier}/credentials/{id}", wrapper.DeleteCredential)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v1/{identifier}/credentials/{id}", wrapper.GetCredential)
@@ -4411,6 +4601,52 @@ func (response CreateLinkQrCode500JSONResponse) VisitCreateLinkQrCodeResponse(w 
 	return json.NewEncoder(w).Encode(response)
 }
 
+type GetCredentialsPaginatedRequestObject struct {
+	Identifier PathIdentifier `json:"identifier"`
+	Page       uint           `json:"page,omitempty"`
+	Params     GetCredentialsPaginatedParams
+}
+
+type GetCredentialsPaginatedResponseObject interface {
+	VisitGetCredentialsPaginatedResponse(w http.ResponseWriter) error
+}
+
+type GetCredentialsPaginated200JSONResponse CredentialsPaginated
+
+func (response GetCredentialsPaginated200JSONResponse) VisitGetCredentialsPaginatedResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetCredentialsPaginated400JSONResponse struct{ N400JSONResponse }
+
+func (response GetCredentialsPaginated400JSONResponse) VisitGetCredentialsPaginatedResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetCredentialsPaginated404JSONResponse struct{ N404JSONResponse }
+
+func (response GetCredentialsPaginated404JSONResponse) VisitGetCredentialsPaginatedResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(404)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type GetCredentialsPaginated500JSONResponse struct{ N500JSONResponse }
+
+func (response GetCredentialsPaginated500JSONResponse) VisitGetCredentialsPaginatedResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
 type GetRevocationStatusV2RequestObject struct {
 	Identifier PathIdentifier `json:"identifier"`
 	Nonce      PathNonce      `json:"nonce"`
@@ -4495,6 +4731,51 @@ func (response RevokeCredential404JSONResponse) VisitRevokeCredentialResponse(w 
 type RevokeCredential500JSONResponse struct{ N500JSONResponse }
 
 func (response RevokeCredential500JSONResponse) VisitRevokeCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteCredentialRequestObject struct {
+	Identifier PathIdentifier `json:"identifier"`
+	Id         PathClaim      `json:"id"`
+}
+
+type DeleteCredentialResponseObject interface {
+	VisitDeleteCredentialResponse(w http.ResponseWriter) error
+}
+
+type DeleteCredential200JSONResponse GenericMessage
+
+func (response DeleteCredential200JSONResponse) VisitDeleteCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteCredential400JSONResponse struct{ N400JSONResponse }
+
+func (response DeleteCredential400JSONResponse) VisitDeleteCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteCredential401JSONResponse struct{ N401JSONResponse }
+
+func (response DeleteCredential401JSONResponse) VisitDeleteCredentialResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type DeleteCredential500JSONResponse struct{ N500JSONResponse }
+
+func (response DeleteCredential500JSONResponse) VisitDeleteCredentialResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(500)
 
@@ -4991,12 +5272,18 @@ type StrictServerInterface interface {
 	// Create Authentication Link QRCode
 	// (POST /v1/{identifier}/credentials/links/{id}/qrcode)
 	CreateLinkQrCode(ctx context.Context, request CreateLinkQrCodeRequestObject) (CreateLinkQrCodeResponseObject, error)
+	// Get Credentials Paginated
+	// (GET /v1/{identifier}/credentials/page/{page})
+	GetCredentialsPaginated(ctx context.Context, request GetCredentialsPaginatedRequestObject) (GetCredentialsPaginatedResponseObject, error)
 	// Get Revocation Status
 	// (GET /v1/{identifier}/credentials/revocation/status/{nonce})
 	GetRevocationStatusV2(ctx context.Context, request GetRevocationStatusV2RequestObject) (GetRevocationStatusV2ResponseObject, error)
 	// Revoke Credential
 	// (POST /v1/{identifier}/credentials/revoke/{nonce})
 	RevokeCredential(ctx context.Context, request RevokeCredentialRequestObject) (RevokeCredentialResponseObject, error)
+	// Delete Credential
+	// (DELETE /v1/{identifier}/credentials/{id})
+	DeleteCredential(ctx context.Context, request DeleteCredentialRequestObject) (DeleteCredentialResponseObject, error)
 	// Get Claim
 	// (GET /v1/{identifier}/credentials/{id})
 	GetCredential(ctx context.Context, request GetCredentialRequestObject) (GetCredentialResponseObject, error)
@@ -6035,6 +6322,34 @@ func (sh *strictHandler) CreateLinkQrCode(w http.ResponseWriter, r *http.Request
 	}
 }
 
+// GetCredentialsPaginated operation middleware
+func (sh *strictHandler) GetCredentialsPaginated(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, page uint, params GetCredentialsPaginatedParams) {
+	var request GetCredentialsPaginatedRequestObject
+
+	request.Identifier = identifier
+	request.Page = page
+	request.Params = params
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.GetCredentialsPaginated(ctx, request.(GetCredentialsPaginatedRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "GetCredentialsPaginated")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(GetCredentialsPaginatedResponseObject); ok {
+		if err := validResponse.VisitGetCredentialsPaginatedResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
 // GetRevocationStatusV2 operation middleware
 func (sh *strictHandler) GetRevocationStatusV2(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, nonce PathNonce) {
 	var request GetRevocationStatusV2RequestObject
@@ -6082,6 +6397,33 @@ func (sh *strictHandler) RevokeCredential(w http.ResponseWriter, r *http.Request
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(RevokeCredentialResponseObject); ok {
 		if err := validResponse.VisitRevokeCredentialResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// DeleteCredential operation middleware
+func (sh *strictHandler) DeleteCredential(w http.ResponseWriter, r *http.Request, identifier PathIdentifier, id PathClaim) {
+	var request DeleteCredentialRequestObject
+
+	request.Identifier = identifier
+	request.Id = id
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.DeleteCredential(ctx, request.(DeleteCredentialRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "DeleteCredential")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(DeleteCredentialResponseObject); ok {
+		if err := validResponse.VisitDeleteCredentialResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -713,10 +713,10 @@ type GetLinkQRCodeParams struct {
 type GetCredentialsPaginatedParams struct {
 	Did *string `form:"did,omitempty" json:"did,omitempty"`
 
-	// Status Schema type:
-	//   * `all` - All Schemas. (default value)
-	//   * `revoked` - Only revoked schemas
-	//   * `expired` - Only expired schemas
+	// Status Credential status:
+	//   * `all` - All Credentials. (default value)
+	//   * `revoked` - Only revoked credentials
+	//   * `expired` - Only expired credentials
 	Status *GetCredentialsPaginatedParamsStatus `form:"status,omitempty" json:"status,omitempty"`
 
 	// Query Query string to do full text search

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -53,6 +53,13 @@ const (
 	Iden3BasicDisplayMethodV1 DisplayMethodType = "Iden3BasicDisplayMethodV1"
 )
 
+// Defines values for GetIdentitiesResponseAuthBJJCredentialStatus.
+const (
+	Iden3OnchainSparseMerkleTreeProof2023 GetIdentitiesResponseAuthBJJCredentialStatus = "Iden3OnchainSparseMerkleTreeProof2023"
+	Iden3ReverseSparseMerkleTreeProof     GetIdentitiesResponseAuthBJJCredentialStatus = "Iden3ReverseSparseMerkleTreeProof"
+	Iden3commRevocationStatusV10          GetIdentitiesResponseAuthBJJCredentialStatus = "Iden3commRevocationStatusV1.0"
+)
+
 // Defines values for LinkStatus.
 const (
 	LinkStatusActive   LinkStatus = "active"
@@ -328,6 +335,18 @@ type GetConnectionResponse struct {
 
 // GetConnectionsResponse defines model for GetConnectionsResponse.
 type GetConnectionsResponse = []GetConnectionResponse
+
+// GetIdentitiesResponse defines model for GetIdentitiesResponse.
+type GetIdentitiesResponse struct {
+	AuthBJJCredentialStatus *GetIdentitiesResponseAuthBJJCredentialStatus `json:"authBJJCredentialStatus,omitempty"`
+	Blockchain              string                                        `json:"blockchain"`
+	Identifier              string                                        `json:"identifier"`
+	Method                  string                                        `json:"method"`
+	Network                 string                                        `json:"network"`
+}
+
+// GetIdentitiesResponseAuthBJJCredentialStatus defines model for GetIdentitiesResponse.AuthBJJCredentialStatus.
+type GetIdentitiesResponseAuthBJJCredentialStatus string
 
 // GetIdentityDetailsResponse defines model for GetIdentityDetailsResponse.
 type GetIdentityDetailsResponse struct {
@@ -3495,7 +3514,7 @@ type GetIdentitiesResponseObject interface {
 	VisitGetIdentitiesResponse(w http.ResponseWriter) error
 }
 
-type GetIdentities200JSONResponse []string
+type GetIdentities200JSONResponse []GetIdentitiesResponse
 
 func (response GetIdentities200JSONResponse) VisitGetIdentitiesResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/api/connections.go
+++ b/internal/api/connections.go
@@ -212,9 +212,9 @@ func getConnectionsFilter(req GetConnectionsRequestObject) (*ports.NewGetAllConn
 			var err error
 			field, desc := strings.CutPrefix(strings.TrimSpace(string(sortBy)), "-")
 			switch GetConnectionsParamsSort(field) {
-			case CreatedAt:
+			case GetConnectionsParamsSortCreatedAt:
 				err = orderBy.Add(ports.ConnectionsCreatedAt, desc)
-			case UserID:
+			case GetConnectionsParamsSortUserID:
 				err = orderBy.Add(ports.ConnectionsUserID, desc)
 			default:
 				return nil, errors.New("wrong sort by value")

--- a/internal/api/credentials.go
+++ b/internal/api/credentials.go
@@ -637,7 +637,13 @@ func getCredentialsFilter(ctx context.Context, req GetCredentialsPaginatedReques
 		}
 	}
 
-	filter.Page = &req.Page
+	if req.Params.Page != nil {
+		if *req.Params.Page <= 0 {
+			return nil, errors.New("page param must be higher than 0")
+		}
+		filter.Page = req.Params.Page
+	}
+
 	if req.Params.Sort != nil {
 		for _, sortBy := range *req.Params.Sort {
 			var err error

--- a/internal/api/credentials.go
+++ b/internal/api/credentials.go
@@ -44,6 +44,24 @@ func (s *Server) CreateCredential(ctx context.Context, request CreateCredentialR
 	}
 }
 
+// DeleteCredential deletes a credential
+func (s *Server) DeleteCredential(ctx context.Context, request DeleteCredentialRequestObject) (DeleteCredentialResponseObject, error) {
+	clID, err := uuid.Parse(request.Id)
+	if err != nil {
+		return DeleteCredential400JSONResponse{N400JSONResponse{"invalid claim id"}}, nil
+	}
+
+	err = s.claimService.Delete(ctx, clID)
+	if err != nil {
+		if errors.Is(err, services.ErrCredentialNotFound) {
+			return DeleteCredential400JSONResponse{N400JSONResponse{"The given credential does not exist"}}, nil
+		}
+		return DeleteCredential500JSONResponse{N500JSONResponse{"There was an error deleting the credential"}}, nil
+	}
+
+	return DeleteCredential200JSONResponse{Message: "Credential successfully deleted"}, nil
+}
+
 // CreateClaim is claim creation controller
 // deprecated - Use CreateCredential instead
 func (s *Server) CreateClaim(ctx context.Context, request CreateClaimRequestObject) (CreateClaimResponseObject, error) {
@@ -281,6 +299,47 @@ func (s *Server) GetCredential(ctx context.Context, request GetCredentialRequest
 		log.Error(ctx, "unexpected return type", "type", fmt.Sprintf("%T", ret))
 		return GetCredential500JSONResponse{N500JSONResponse{Message: fmt.Sprintf("unexpected return type: %T", ret)}}, nil
 	}
+}
+
+// GetCredentialsPaginated returns a collection of credentials that matches the request.
+func (s *Server) GetCredentialsPaginated(ctx context.Context, request GetCredentialsPaginatedRequestObject) (GetCredentialsPaginatedResponseObject, error) {
+	filter, err := getCredentialsFilter(ctx, request)
+	if err != nil {
+		return GetCredentialsPaginated400JSONResponse{N400JSONResponse{Message: err.Error()}}, nil
+	}
+
+	did, err := w3c.ParseDID(request.Identifier)
+	if err != nil {
+		return GetCredentialsPaginated400JSONResponse{N400JSONResponse{"invalid did"}}, nil
+	}
+
+	credentials, total, err := s.claimService.GetAll(ctx, *did, filter)
+	if err != nil {
+		log.Error(ctx, "loading credentials", "err", err, "req", request)
+		return GetCredentialsPaginated500JSONResponse{N500JSONResponse{Message: err.Error()}}, nil
+	}
+	response := make([]Credential, len(credentials))
+	for i, credential := range credentials {
+		w3c, err := schema.FromClaimModelToW3CCredential(*credential)
+		if err != nil {
+			log.Error(ctx, "creating credentials response", "err", err, "req", request)
+			return GetCredentialsPaginated500JSONResponse{N500JSONResponse{"Invalid claim format"}}, nil
+		}
+		response[i] = credentialResponse(w3c, credential)
+	}
+
+	resp := GetCredentialsPaginated200JSONResponse{
+		Items: response,
+		Meta: PaginatedMetadata{
+			MaxResults: filter.MaxResults,
+			Page:       1, // default
+			Total:      total,
+		},
+	}
+	if filter.Page != nil {
+		resp.Meta.Page = *filter.Page
+	}
+	return resp, nil
 }
 
 // GetClaim is the controller to get a claim.
@@ -541,4 +600,64 @@ func toGetClaimQrCode200JSONResponse(claim *domain.Claim, hostURL string) GetCla
 		Typ:  string(packers.MediaTypePlainMessage),
 		Type: string(protocol.CredentialOfferMessageType),
 	}
+}
+
+func getCredentialsFilter(ctx context.Context, req GetCredentialsPaginatedRequestObject) (*ports.ClaimsFilter, error) {
+	filter := &ports.ClaimsFilter{}
+	if req.Params.Did != nil {
+		did, err := w3c.ParseDID(*req.Params.Did)
+		if err != nil {
+			log.Warn(ctx, "get credentials. Parsing did", "err", err, "did", did)
+			return nil, errors.New("cannot parse did parameter: wrong format")
+		}
+		filter.Subject, filter.FTSAndCond = did.String(), true
+	}
+	if req.Params.Status != nil {
+		switch GetCredentialsPaginatedParamsStatus(strings.ToLower(string(*req.Params.Status))) {
+		case Revoked:
+			filter.Revoked = common.ToPointer(true)
+		case Expired:
+			filter.ExpiredOn = common.ToPointer(time.Now())
+		case All:
+			// Nothing to be done
+		default:
+			return nil, errors.New("wrong type value. Allowed values: [all, revoked, expired]")
+		}
+	}
+	if req.Params.Query != nil {
+		filter.FTSQuery = *req.Params.Query
+	}
+
+	filter.MaxResults = 50
+	if req.Params.MaxResults != nil {
+		if *req.Params.MaxResults <= 0 {
+			filter.MaxResults = 50
+		} else {
+			filter.MaxResults = *req.Params.MaxResults
+		}
+	}
+
+	filter.Page = &req.Page
+	if req.Params.Sort != nil {
+		for _, sortBy := range *req.Params.Sort {
+			var err error
+			field, desc := strings.CutPrefix(strings.TrimSpace(string(sortBy)), "-")
+			switch GetCredentialsPaginatedParamsSort(field) {
+			case GetCredentialsPaginatedParamsSortSchemaType:
+				err = filter.OrderBy.Add(ports.CredentialSchemaType, desc)
+			case GetCredentialsPaginatedParamsSortCreatedAt:
+				err = filter.OrderBy.Add(ports.CredentialCreatedAt, desc)
+			case GetCredentialsPaginatedParamsSortExpiresAt:
+				err = filter.OrderBy.Add(ports.CredentialExpiresAt, desc)
+			case GetCredentialsPaginatedParamsSortRevoked:
+				err = filter.OrderBy.Add(ports.CredentialRevoked, desc)
+			default:
+				return nil, errors.New("wrong sort by value")
+			}
+			if err != nil {
+				return nil, errors.New("repeated sort by value field")
+			}
+		}
+	}
+	return filter, nil
 }

--- a/internal/api/credentials_test.go
+++ b/internal/api/credentials_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -447,6 +448,93 @@ func TestServer_CreateCredential(t *testing.T) {
 				var response CreateClaim422JSONResponse
 				require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 				assert.EqualValues(t, tc.expected.response, response)
+			}
+		})
+	}
+}
+
+func TestServer_DeleteCredential(t *testing.T) {
+	server := newTestServer(t, nil)
+	ctx := context.Background()
+	handler := getHandler(ctx, server)
+
+	idStr := "did:polygonid:polygon:mumbai:2qLduMv2z7hnuhzkcTWesCUuJKpRVDEThztM4tsJUj"
+	identity := &domain.Identity{
+		Identifier: idStr,
+	}
+	fixture := tests.NewFixture(storage)
+	fixture.CreateIdentity(t, identity)
+
+	claim := fixture.NewClaim(t, identity.Identifier)
+	fixture.CreateClaim(t, claim)
+
+	type expected struct {
+		httpCode int
+		message  *string
+	}
+
+	type testConfig struct {
+		name         string
+		credentialID uuid.UUID
+		auth         func() (string, string)
+		expected     expected
+	}
+
+	for _, tc := range []testConfig{
+		{
+			name: "No auth header",
+			auth: authWrong,
+			expected: expected{
+				httpCode: http.StatusUnauthorized,
+			},
+		},
+		{
+			name:         "should get an error, not existing claim",
+			credentialID: uuid.New(),
+			auth:         authOk,
+			expected: expected{
+				httpCode: http.StatusBadRequest,
+				message:  common.ToPointer("The given credential does not exist"),
+			},
+		},
+		{
+			name:         "should delete the credential",
+			credentialID: claim.ID,
+			auth:         authOk,
+			expected: expected{
+				httpCode: http.StatusOK,
+				message:  common.ToPointer("Credential successfully deleted"),
+			},
+		},
+		{
+			name:         "should get an error, a credential cannot be deleted twice",
+			credentialID: claim.ID,
+			auth:         authOk,
+			expected: expected{
+				httpCode: http.StatusBadRequest,
+				message:  common.ToPointer("The given credential does not exist"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			url := fmt.Sprintf("/v1/%s/credentials/%s", *claim.Identifier, tc.credentialID.String())
+			req, err := http.NewRequest("DELETE", url, nil)
+			req.SetBasicAuth(tc.auth())
+			require.NoError(t, err)
+
+			handler.ServeHTTP(rr, req)
+
+			require.Equal(t, tc.expected.httpCode, rr.Code)
+			switch tc.expected.httpCode {
+			case http.StatusBadRequest:
+				var response DeleteCredential400JSONResponse
+				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+				assert.Equal(t, *tc.expected.message, response.Message)
+			case http.StatusOK:
+				var response DeleteCredential200JSONResponse
+				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+				assert.Equal(t, *tc.expected.message, response.Message)
 			}
 		})
 	}
@@ -1060,6 +1148,488 @@ func TestServer_GetCredentials(t *testing.T) {
 				var response GetClaims500JSONResponse
 				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 				assert.Equal(t, response.Message, v.Message)
+			}
+		})
+	}
+}
+
+func TestServer_GetCredentialsPaginated(t *testing.T) {
+	const (
+		method     = "polygonid"
+		blockchain = "polygon"
+		network    = "amoy"
+		BJJ        = "BJJ"
+	)
+	ctx := context.Background()
+
+	server := newTestServer(t, nil)
+	identityMultipleClaims, err := server.identityService.Create(ctx, "https://localhost.com", &ports.DIDCreationOptions{Method: method, Blockchain: blockchain, Network: network, KeyType: BJJ})
+	require.NoError(t, err)
+
+	did, err := w3c.ParseDID(identityMultipleClaims.Identifier)
+	require.NoError(t, err)
+
+	typeC := "KYCAgeCredential"
+	merklizedRootPosition := "index"
+	schemaURL := "https://raw.githubusercontent.com/iden3/claim-schema-vocab/main/schemas/json/KYCAgeCredential-v3.json"
+
+	credentialSubject := map[string]any{
+		"id":           "did:polygonid:polygon:mumbai:2qE1BZ7gcmEoP2KppvFPCZqyzyb5tK9T6Gec5HFANQ",
+		"birthday":     19960424,
+		"documentType": 2,
+	}
+
+	claimsService := server.claimService
+
+	// Never expires
+	_, err = claimsService.Save(ctx, ports.NewCreateClaimRequest(did, nil, schemaURL, credentialSubject, nil, typeC, nil, nil, &merklizedRootPosition, ports.ClaimRequestProofs{BJJSignatureProof2021: true, Iden3SparseMerkleTreeProof: true},
+		nil, false, verifiable.Iden3commRevocationStatusV1, nil, nil, nil))
+	require.NoError(t, err)
+
+	future := time.Now().Add(1000 * time.Hour)
+	past := time.Now().Add(-1000 * time.Hour)
+	// Expires in future
+	_, err = claimsService.Save(ctx, ports.NewCreateClaimRequest(did, nil, schemaURL, credentialSubject, &future, typeC, nil, nil, &merklizedRootPosition, ports.ClaimRequestProofs{BJJSignatureProof2021: true, Iden3SparseMerkleTreeProof: false}, nil, false, verifiable.Iden3commRevocationStatusV1, nil, nil, nil))
+	require.NoError(t, err)
+
+	// Expired
+	expiredClaim, err := claimsService.Save(ctx, ports.NewCreateClaimRequest(did, nil, schemaURL, credentialSubject, &past, typeC, nil, nil, &merklizedRootPosition, ports.ClaimRequestProofs{BJJSignatureProof2021: true, Iden3SparseMerkleTreeProof: false}, nil, false, verifiable.Iden3commRevocationStatusV1, nil, nil, nil))
+	require.NoError(t, err)
+
+	// non expired, but revoked
+	revoked, err := claimsService.Save(ctx, ports.NewCreateClaimRequest(did, nil, schemaURL, credentialSubject, &future, typeC, nil, nil, &merklizedRootPosition,
+		ports.ClaimRequestProofs{BJJSignatureProof2021: false, Iden3SparseMerkleTreeProof: true},
+		nil, false, verifiable.Iden3commRevocationStatusV1, nil, nil, nil))
+	require.NoError(t, err)
+
+	id, err := w3c.ParseDID(*revoked.Identifier)
+	require.NoError(t, err)
+	require.NoError(t, claimsService.Revoke(ctx, *id, uint64(revoked.RevNonce), "because I can"))
+
+	iReq := ports.NewImportSchemaRequest(schemaURL, typeC, common.ToPointer("someTitle"), uuid.NewString(), common.ToPointer("someDescription"))
+	_, err = server.schemaService.ImportSchema(ctx, *did, iReq)
+	require.NoError(t, err)
+
+	handler := getHandler(context.Background(), server)
+
+	type expected struct {
+		credentialsCount int
+		page             uint
+		maxResults       uint
+		total            uint
+		httpCode         int
+		errorMsg         string
+	}
+
+	type testConfig struct {
+		name       string
+		auth       func() (string, string)
+		did        *string
+		query      *string
+		sort       *string
+		status     *string
+		page       *int
+		maxResults *int
+		expected   expected
+	}
+	for _, tc := range []testConfig{
+		{
+			name: "Not authorized",
+			auth: authWrong,
+			page: common.ToPointer(1),
+			expected: expected{
+				httpCode: http.StatusUnauthorized,
+			},
+		},
+		{
+			name:   "Wrong status",
+			auth:   authOk,
+			page:   common.ToPointer(1),
+			status: common.ToPointer("wrong"),
+			expected: expected{
+				httpCode: http.StatusBadRequest,
+				errorMsg: "wrong type value. Allowed values: [all, revoked, expired]",
+			},
+		},
+		{
+			name: "wrong did",
+			auth: authOk,
+			page: common.ToPointer(1),
+			did:  common.ToPointer("wrongdid:"),
+			expected: expected{
+				httpCode: http.StatusBadRequest,
+				errorMsg: "cannot parse did parameter: wrong format",
+			},
+		},
+		{
+			name: "pagination. Page is < 1 not allowed",
+			auth: authOk,
+			page: common.ToPointer(0),
+			expected: expected{
+				httpCode: http.StatusBadRequest,
+				errorMsg: "page param must be higher than 0",
+			},
+		},
+		{
+			name:       "pagination. max_results < 1 return default max results",
+			auth:       authOk,
+			page:       common.ToPointer(1),
+			maxResults: common.ToPointer(0),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            4,
+				maxResults:       50,
+				page:             1,
+				credentialsCount: 4,
+			},
+		},
+		{
+			name: "Default max results",
+			auth: authOk,
+			page: common.ToPointer(1),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            4,
+				maxResults:       50,
+				page:             1,
+				credentialsCount: 4,
+			},
+		},
+		{
+			name:   "Status 'all' explicit",
+			auth:   authOk,
+			page:   common.ToPointer(1),
+			status: common.ToPointer("all"),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            4,
+				maxResults:       50,
+				page:             1,
+				credentialsCount: 4,
+			},
+		},
+		{
+			name:       "GetCredentialsPaginated all explicit, page 1 with 2 results",
+			auth:       authOk,
+			status:     common.ToPointer("all"),
+			page:       common.ToPointer(1),
+			maxResults: common.ToPointer(2),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            4,
+				maxResults:       2,
+				page:             1,
+				credentialsCount: 2,
+			},
+		},
+		{
+			name:       "GetCredentialsPaginated all explicit, page 2 with 2 results",
+			auth:       authOk,
+			status:     common.ToPointer("all"),
+			page:       common.ToPointer(2),
+			maxResults: common.ToPointer(2),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            4,
+				maxResults:       2,
+				page:             2,
+				credentialsCount: 2,
+			},
+		},
+		{
+			name:       "GetCredentialsPaginated all explicit, page 3 with 2 results. No results",
+			auth:       authOk,
+			status:     common.ToPointer("all"),
+			page:       common.ToPointer(3),
+			maxResults: common.ToPointer(2),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            4,
+				maxResults:       2,
+				page:             3,
+				credentialsCount: 0,
+			},
+		},
+		{
+			name:   "GetCredentialsPaginated all from existing did",
+			auth:   authOk,
+			status: common.ToPointer("all"),
+			page:   common.ToPointer(1),
+			did:    &expiredClaim.OtherIdentifier,
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            4,
+				maxResults:       50,
+				page:             1,
+				credentialsCount: 4,
+			},
+		},
+		{
+			name:   "GetCredentialsPaginated all from non existing did. Expecting empty list",
+			auth:   authOk,
+			status: common.ToPointer("all"),
+			page:   common.ToPointer(1),
+			did:    common.ToPointer("did:iden3:tJU7z1dbKyKYLiaopZ5tN6Zjsspq7QhYayiR31RFa"),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            0,
+				maxResults:       50,
+				page:             1,
+				credentialsCount: 0,
+			},
+		},
+		{
+			name:   "Revoked",
+			auth:   authOk,
+			status: common.ToPointer("revoked"),
+			page:   common.ToPointer(1),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            1,
+				maxResults:       50,
+				page:             1,
+				credentialsCount: 1,
+			},
+		},
+		{
+			name:   "REVOKED",
+			auth:   authOk,
+			status: common.ToPointer("REVOKED"),
+			page:   common.ToPointer(1),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            1,
+				maxResults:       50,
+				page:             1,
+				credentialsCount: 1,
+			},
+		},
+		{
+			name:   "Expired",
+			auth:   authOk,
+			status: common.ToPointer("expired"),
+			page:   common.ToPointer(1),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            1,
+				maxResults:       50,
+				page:             1,
+				credentialsCount: 1,
+			},
+		},
+		{
+			name:  "Search by did and other words in query params:",
+			auth:  authOk,
+			page:  common.ToPointer(1),
+			query: common.ToPointer("some words and " + revoked.OtherIdentifier),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            4,
+				maxResults:       50,
+				page:             1,
+				credentialsCount: 4,
+			},
+		},
+		{
+			name:  "Search by partial did and other words in query params:",
+			auth:  authOk,
+			page:  common.ToPointer(1),
+			query: common.ToPointer("some words and " + revoked.OtherIdentifier[9:14]),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            4,
+				maxResults:       50,
+				page:             1,
+				credentialsCount: 4,
+			},
+		},
+		{
+			name:  "Search by did in query params:",
+			auth:  authOk,
+			page:  common.ToPointer(1),
+			query: &revoked.OtherIdentifier,
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            4,
+				maxResults:       50,
+				page:             1,
+				credentialsCount: 4,
+			},
+		},
+		{
+			name:  "Search by attributes in query params",
+			auth:  authOk,
+			query: common.ToPointer("birthday"),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            4,
+				maxResults:       50,
+				page:             1,
+				credentialsCount: 4,
+			},
+		},
+		{
+			name:  "Search by attributes in query params, partial word",
+			auth:  authOk,
+			page:  common.ToPointer(1),
+			query: common.ToPointer("rthd"),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            4,
+				maxResults:       50,
+				page:             1,
+				credentialsCount: 4,
+			},
+		},
+		{
+			name:  "Search by partial did in query params:",
+			auth:  authOk,
+			query: common.ToPointer(revoked.OtherIdentifier[9:14]),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            4,
+				maxResults:       50,
+				page:             1,
+				credentialsCount: 4,
+			},
+		},
+		{
+			name:  "FTS is doing and OR when no did passed:",
+			auth:  authOk,
+			query: common.ToPointer("birthday schema attribute not the rest of words this sentence"),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            4,
+				maxResults:       50,
+				page:             1,
+				credentialsCount: 4,
+			},
+		},
+		{
+			name:  "FTS is doing and AND when did passed:",
+			auth:  authOk,
+			did:   &expiredClaim.OtherIdentifier,
+			query: common.ToPointer("not existing words"),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            0,
+				maxResults:       50,
+				page:             1,
+				credentialsCount: 0,
+			},
+		},
+		{
+			name: "Wrong order by",
+			auth: authOk,
+			sort: common.ToPointer("wrongField"),
+			expected: expected{
+				httpCode: http.StatusBadRequest,
+				errorMsg: "wrong sort by value",
+			},
+		},
+		{
+			name: "Order by one field",
+			auth: authOk,
+			sort: common.ToPointer("createdAt"),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            4,
+				maxResults:       50,
+				page:             1,
+				credentialsCount: 4,
+			},
+		},
+		{
+			name: "Order by 2 fields",
+			auth: authOk,
+			sort: common.ToPointer("-schemaType, createdAt"),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            4,
+				maxResults:       50,
+				page:             1,
+				credentialsCount: 4,
+			},
+		},
+		{
+			name: "Order by all fields",
+			auth: authOk,
+			sort: common.ToPointer("-schemaType, createdAt, -expiresAt, revoked"),
+			expected: expected{
+				httpCode:         http.StatusOK,
+				total:            4,
+				maxResults:       50,
+				page:             1,
+				credentialsCount: 4,
+			},
+		},
+		{
+			name: "Order by 2 repeated fields",
+			auth: authOk,
+			sort: common.ToPointer("createdAt, createdAt"),
+			expected: expected{
+				httpCode: http.StatusBadRequest,
+				errorMsg: "repeated sort by value field",
+			},
+		},
+		{
+			name: "Order by 2 repeated contradictory fields ",
+			auth: authOk,
+			sort: common.ToPointer("createdAt, -createdAt"),
+			expected: expected{
+				httpCode: http.StatusBadRequest,
+				errorMsg: "repeated sort by value field",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			endpoint := url.URL{Path: fmt.Sprintf("/v1/%s/credentials/search", identityMultipleClaims.Identifier)}
+			queryParams := make([]string, 0)
+			if tc.query != nil {
+				queryParams = append(queryParams, "query="+*tc.query)
+			}
+			if tc.sort != nil {
+				queryParams = append(queryParams, "sort="+*tc.sort)
+			}
+			if tc.status != nil {
+				queryParams = append(queryParams, "status="+*tc.status)
+			}
+			if tc.did != nil {
+				queryParams = append(queryParams, "did="+*tc.did)
+			}
+			if tc.page != nil {
+				queryParams = append(queryParams, "page="+strconv.Itoa(*tc.page))
+			}
+			if tc.maxResults != nil {
+				queryParams = append(queryParams, "max_results="+strconv.Itoa(*tc.maxResults))
+			}
+			endpoint.RawQuery = strings.Join(queryParams, "&")
+			req, err := http.NewRequest("GET", endpoint.String(), nil)
+			req.SetBasicAuth(tc.auth())
+			require.NoError(t, err)
+
+			handler.ServeHTTP(rr, req)
+
+			require.Equal(t, tc.expected.httpCode, rr.Code)
+			switch tc.expected.httpCode {
+			case http.StatusOK:
+				var response GetCredentialsPaginated200JSONResponse
+				require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+				assert.Equal(t, tc.expected.total, response.Meta.Total)
+				assert.Equal(t, tc.expected.credentialsCount, len(response.Items))
+				assert.Equal(t, tc.expected.maxResults, response.Meta.MaxResults)
+				assert.Equal(t, tc.expected.page, response.Meta.Page)
+
+			case http.StatusBadRequest:
+				var response GetCredentialsPaginated400JSONResponse
+				require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+				assert.Equal(t, tc.expected.errorMsg, response.Message)
+
+			case http.StatusInternalServerError:
+				var response GetCredentialsPaginated400JSONResponse
+				require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+				assert.Equal(t, tc.expected.errorMsg, response.Message)
 			}
 		})
 	}

--- a/internal/api/credentials_test.go
+++ b/internal/api/credentials_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	core "github.com/iden3/go-iden3-core/v2"
 	"github.com/iden3/go-iden3-core/v2/w3c"
 	"github.com/iden3/go-schema-processor/v2/verifiable"
 	"github.com/iden3/iden3comm/v2/packers"
@@ -26,6 +27,7 @@ import (
 	"github.com/polygonid/sh-id-platform/internal/core/event"
 	"github.com/polygonid/sh-id-platform/internal/core/ports"
 	"github.com/polygonid/sh-id-platform/internal/db/tests"
+	"github.com/polygonid/sh-id-platform/internal/kms"
 )
 
 func TestServer_RevokeClaim(t *testing.T) {
@@ -457,14 +459,9 @@ func TestServer_DeleteCredential(t *testing.T) {
 	server := newTestServer(t, nil)
 	ctx := context.Background()
 	handler := getHandler(ctx, server)
-
-	idStr := "did:polygonid:polygon:mumbai:2qLduMv2z7hnuhzkcTWesCUuJKpRVDEThztM4tsJUj"
-	identity := &domain.Identity{
-		Identifier: idStr,
-	}
+	identity, err := server.Services.identity.Create(ctx, "http://polygon-test", &ports.DIDCreationOptions{Method: core.DIDMethodIden3, Blockchain: core.Polygon, Network: core.Amoy, KeyType: kms.KeyTypeBabyJubJub})
+	require.NoError(t, err)
 	fixture := tests.NewFixture(storage)
-	fixture.CreateIdentity(t, identity)
-
 	claim := fixture.NewClaim(t, identity.Identifier)
 	fixture.CreateClaim(t, claim)
 

--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -125,6 +125,7 @@ func (s *Server) GetIdentities(ctx context.Context, request GetIdentitiesRequest
 		}}, nil
 	}
 
+	partsLength := 4
 	for _, identity := range identities {
 		did, err := w3c.ParseDID(identity)
 		if err != nil {
@@ -145,7 +146,7 @@ func (s *Server) GetIdentities(ctx context.Context, request GetIdentitiesRequest
 		}
 
 		items := strings.Split(identity, ":")
-		if len(items) < 4 {
+		if len(items) < partsLength {
 			return GetIdentities500JSONResponse{N500JSONResponse{
 				Message: "Invalid identity",
 			}}, nil

--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 
 	core "github.com/iden3/go-iden3-core/v2"
 	"github.com/iden3/go-iden3-core/v2/w3c"
@@ -115,13 +116,48 @@ func (s *Server) CreateIdentity(ctx context.Context, request CreateIdentityReque
 
 // GetIdentities is the controller to get identities
 func (s *Server) GetIdentities(ctx context.Context, request GetIdentitiesRequestObject) (GetIdentitiesResponseObject, error) {
-	var response GetIdentities200JSONResponse
 	var err error
-	response, err = s.identityService.Get(ctx)
+	var response GetIdentities200JSONResponse
+	identities, err := s.identityService.Get(ctx)
 	if err != nil {
 		return GetIdentities500JSONResponse{N500JSONResponse{
 			Message: err.Error(),
 		}}, nil
+	}
+
+	for _, identity := range identities {
+		did, err := w3c.ParseDID(identity)
+		if err != nil {
+			return GetIdentities500JSONResponse{N500JSONResponse{
+				Message: err.Error(),
+			}}, nil
+		}
+
+		var authBjjCredStatus *GetIdentitiesResponseAuthBJJCredentialStatus
+		authClaim, _ := s.claimService.GetAuthClaim(ctx, did)
+		if authClaim != nil {
+			credentialStatus, _ := authClaim.GetCredentialStatus()
+
+			if credentialStatus != nil {
+				credStatusType := GetIdentitiesResponseAuthBJJCredentialStatus(credentialStatus.Type)
+				authBjjCredStatus = &credStatusType
+			}
+		}
+
+		items := strings.Split(identity, ":")
+		if len(items) < 4 {
+			return GetIdentities500JSONResponse{N500JSONResponse{
+				Message: "Invalid identity",
+			}}, nil
+		}
+
+		response = append(response, GetIdentitiesResponse{
+			Identifier:              identity,
+			Method:                  items[1],
+			Blockchain:              items[2],
+			Network:                 items[3],
+			AuthBJJCredentialStatus: authBjjCredStatus,
+		})
 	}
 
 	return response, nil

--- a/internal/api/identity_test.go
+++ b/internal/api/identity_test.go
@@ -226,8 +226,7 @@ func TestServer_GetIdentities(t *testing.T) {
 	fixture.CreateIdentity(t, identity2)
 
 	type expected struct {
-		httpCode                int
-		authBJJCredentialStatus *GetIdentitiesResponseAuthBJJCredentialStatus
+		httpCode int
 	}
 	type testConfig struct {
 		name     string
@@ -247,8 +246,7 @@ func TestServer_GetIdentities(t *testing.T) {
 			name: "should return all the entities",
 			auth: authOk,
 			expected: expected{
-				httpCode:                200,
-				authBJJCredentialStatus: nil,
+				httpCode: 200,
 			},
 		},
 	} {
@@ -265,7 +263,6 @@ func TestServer_GetIdentities(t *testing.T) {
 				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 				assert.Equal(t, tc.expected.httpCode, rr.Code)
 				assert.True(t, len(response) >= 2)
-				assert.Equal(t, tc.expected.authBJJCredentialStatus, response[0].AuthBJJCredentialStatus)
 			}
 		})
 	}

--- a/internal/api/identity_test.go
+++ b/internal/api/identity_test.go
@@ -226,7 +226,8 @@ func TestServer_GetIdentities(t *testing.T) {
 	fixture.CreateIdentity(t, identity2)
 
 	type expected struct {
-		httpCode int
+		httpCode                int
+		authBJJCredentialStatus *GetIdentitiesResponseAuthBJJCredentialStatus
 	}
 	type testConfig struct {
 		name     string
@@ -246,7 +247,8 @@ func TestServer_GetIdentities(t *testing.T) {
 			name: "should return all the entities",
 			auth: authOk,
 			expected: expected{
-				httpCode: 200,
+				httpCode:                200,
+				authBJJCredentialStatus: nil,
 			},
 		},
 	} {
@@ -263,6 +265,7 @@ func TestServer_GetIdentities(t *testing.T) {
 				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 				assert.Equal(t, tc.expected.httpCode, rr.Code)
 				assert.True(t, len(response) >= 2)
+				assert.Equal(t, tc.expected.authBJJCredentialStatus, response[0].AuthBJJCredentialStatus)
 			}
 		})
 	}


### PR DESCRIPTION
- added GET /credentials/search endpoint with FTS and pagination
- added DELETE /credentials/{id} endpoint
- added PATCH AllowedMethod to CORS settings
- extend GET /identities with `authBJJCredentialStatus`, `method`, `blockchain` and `network`