### PR TITLE
feat: Identity Display Name and supported chain/networks endopoint

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -217,6 +217,47 @@ paths:
         '500':
           $ref: '#/components/responses/500'
 
+  /v1/identities/{identifier}:
+    patch:
+      summary: Update Identity DisplayName field
+      operationId: UpdateIdentityDisplayName
+      description: |
+        Endpoint to update the displayName field of an identity.
+        The displayName field is used to identify the identity in the UI.
+      tags:
+        - Identity
+      security:
+        - basicAuth: [ ]
+      parameters:
+        - $ref: '#/components/parameters/pathIdentifier'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - displayName
+              properties:
+                displayName:
+                  type: string
+                  example: "KYCAgeCredential Issuer identity"
+      responses:
+        '200':
+          description: Identity updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericMessage'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '500':
+          $ref: '#/components/responses/500-CreateIdentity'
+    
   /v1/identities/{identifier}/details:
     get:
       summary: Identity Detail
@@ -1531,6 +1572,10 @@ components:
               x-omitempty: true
               example: "Iden3ReverseSparseMerkleTreeProof"
               enum: [ Iden3commRevocationStatusV1.0, Iden3ReverseSparseMerkleTreeProof, Iden3OnchainSparseMerkleTreeProof2023 ]
+        displayName:
+              type: string
+              x-omitempty: true
+              example: "KYCAgeCredential Issuer identity"
 
     CreateIdentityResponse:
       type: object
@@ -1539,6 +1584,8 @@ components:
         - status
       properties:
         identifier:
+          type: string
+        displayName:
           type: string
         state:
           $ref: '#/components/schemas/IdentityState'
@@ -1699,6 +1746,7 @@ components:
         - method
         - blockchain
         - network
+        - displayName
       properties:
         identifier:
           type: string
@@ -1721,6 +1769,10 @@ components:
           type: string
           x-omitempty: false
           example: "amoy"
+        displayName:
+          type: string
+          x-omitempty: false
+          example: "KYCAgeCredential Issuer identity"
 
     GetConnectionResponse:
       type: object

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -70,6 +70,34 @@ paths:
         '500':
           $ref: '#/components/responses/500'
 
+      
+  /v1/supported-networks:
+    get:
+      summary: Get Supported Networks
+      operationId: GetSupportedNetworks
+      description: get supported blockchains and networks
+      security:
+        - basicAuth: [ ]
+      tags:
+        - Network
+      responses:
+        '200':
+          description: Supported Networks
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SupportedNetworks'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '404':
+          $ref: '#/components/responses/404'
+        '500':
+          $ref: '#/components/responses/500'
+
   #authentication
   /v1/authentication/sessions/{id}:
     get:
@@ -2519,7 +2547,23 @@ components:
         issuerDoc:
           type: object
           format: byte
-
+    
+    SupportedNetworks:
+      type: object
+      x-omitempty: false
+      required:
+        - blockchain
+        - networks
+      properties:
+        blockchain:
+          type: string
+          example: "polygon"
+        networks:
+          type: array
+          items:
+            type: string
+          example: ["amoy", "mumbai"]
+            
   parameters:
     credentialStatusType:
       name: credentialStatusType

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -1746,7 +1746,6 @@ components:
         - method
         - blockchain
         - network
-        - displayName
       properties:
         identifier:
           type: string
@@ -1771,7 +1770,7 @@ components:
           example: "amoy"
         displayName:
           type: string
-          x-omitempty: false
+          x-omitempty: true
           example: "KYCAgeCredential Issuer identity"
 
     GetConnectionResponse:

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -200,6 +200,7 @@ type CreateIdentityRequest struct {
 		Network                 string                                                   `json:"network"`
 		Type                    CreateIdentityRequestDidMetadataType                     `json:"type"`
 	} `json:"didMetadata"`
+	DisplayName *string `json:"displayName,omitempty"`
 }
 
 // CreateIdentityRequestDidMetadataAuthBJJCredentialStatus defines model for CreateIdentityRequest.DidMetadata.AuthBJJCredentialStatus.
@@ -210,9 +211,10 @@ type CreateIdentityRequestDidMetadataType string
 
 // CreateIdentityResponse defines model for CreateIdentityResponse.
 type CreateIdentityResponse struct {
-	Address    *string        `json:"address"`
-	Identifier *string        `json:"identifier,omitempty"`
-	State      *IdentityState `json:"state,omitempty"`
+	Address     *string        `json:"address"`
+	DisplayName *string        `json:"displayName,omitempty"`
+	Identifier  *string        `json:"identifier,omitempty"`
+	State       *IdentityState `json:"state,omitempty"`
 }
 
 // CreateLinkRequest defines model for CreateLinkRequest.
@@ -346,6 +348,7 @@ type GetConnectionsResponse = []GetConnectionResponse
 type GetIdentitiesResponse struct {
 	AuthBJJCredentialStatus *GetIdentitiesResponseAuthBJJCredentialStatus `json:"authBJJCredentialStatus,omitempty"`
 	Blockchain              string                                        `json:"blockchain"`
+	DisplayName             string                                        `json:"displayName"`
 	Identifier              string                                        `json:"identifier"`
 	Method                  string                                        `json:"method"`
 	Network                 string                                        `json:"network"`
@@ -632,6 +635,11 @@ type CreateLinkQrCodeCallbackParams struct {
 	CredentialStatusType *CredentialStatusType `form:"credentialStatusType,omitempty" json:"credentialStatusType,omitempty"`
 }
 
+// UpdateIdentityDisplayNameJSONBody defines parameters for UpdateIdentityDisplayName.
+type UpdateIdentityDisplayNameJSONBody struct {
+	DisplayName string `json:"displayName"`
+}
+
 // GetQrFromStoreParams defines parameters for GetQrFromStore.
 type GetQrFromStoreParams struct {
 	Id *uuid.UUID `form:"id,omitempty" json:"id,omitempty"`
@@ -815,6 +823,9 @@ type CreateLinkQrCodeCallbackTextRequestBody = CreateLinkQrCodeCallbackTextBody
 // CreateIdentityJSONRequestBody defines body for CreateIdentity for application/json ContentType.
 type CreateIdentityJSONRequestBody = CreateIdentityRequest
 
+// UpdateIdentityDisplayNameJSONRequestBody defines body for UpdateIdentityDisplayName for application/json ContentType.
+type UpdateIdentityDisplayNameJSONRequestBody UpdateIdentityDisplayNameJSONBody
+
 // CreateClaimJSONRequestBody defines body for CreateClaim for application/json ContentType.
 type CreateClaimJSONRequestBody = CreateClaimRequest
 
@@ -868,6 +879,9 @@ type ServerInterface interface {
 	// Create Identity
 	// (POST /v1/identities)
 	CreateIdentity(w http.ResponseWriter, r *http.Request)
+	// Update Identity DisplayName field
+	// (PATCH /v1/identities/{identifier})
+	UpdateIdentityDisplayName(w http.ResponseWriter, r *http.Request, identifier PathIdentifier)
 	// Identity Detail
 	// (GET /v1/identities/{identifier}/details)
 	GetIdentityDetails(w http.ResponseWriter, r *http.Request, identifier PathIdentifier)
@@ -1048,6 +1062,12 @@ func (_ Unimplemented) GetIdentities(w http.ResponseWriter, r *http.Request) {
 // Create Identity
 // (POST /v1/identities)
 func (_ Unimplemented) CreateIdentity(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Update Identity DisplayName field
+// (PATCH /v1/identities/{identifier})
+func (_ Unimplemented) UpdateIdentityDisplayName(w http.ResponseWriter, r *http.Request, identifier PathIdentifier) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1520,6 +1540,34 @@ func (siw *ServerInterfaceWrapper) CreateIdentity(w http.ResponseWriter, r *http
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.CreateIdentity(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// UpdateIdentityDisplayName operation middleware
+func (siw *ServerInterfaceWrapper) UpdateIdentityDisplayName(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var err error
+
+	// ------------- Path parameter "identifier" -------------
+	var identifier PathIdentifier
+
+	err = runtime.BindStyledParameterWithOptions("simple", "identifier", chi.URLParam(r, "identifier"), &identifier, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "identifier", Err: err})
+		return
+	}
+
+	ctx = context.WithValue(ctx, BasicAuthScopes, []string{})
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.UpdateIdentityDisplayName(w, r, identifier)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -3193,6 +3241,9 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Post(options.BaseURL+"/v1/identities", wrapper.CreateIdentity)
 	})
 	r.Group(func(r chi.Router) {
+		r.Patch(options.BaseURL+"/v1/identities/{identifier}", wrapper.UpdateIdentityDisplayName)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/v1/identities/{identifier}/details", wrapper.GetIdentityDetails)
 	})
 	r.Group(func(r chi.Router) {
@@ -3661,6 +3712,60 @@ func (response CreateIdentity403JSONResponse) VisitCreateIdentityResponse(w http
 type CreateIdentity500JSONResponse struct{ N500CreateIdentityJSONResponse }
 
 func (response CreateIdentity500JSONResponse) VisitCreateIdentityResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(500)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateIdentityDisplayNameRequestObject struct {
+	Identifier PathIdentifier `json:"identifier"`
+	Body       *UpdateIdentityDisplayNameJSONRequestBody
+}
+
+type UpdateIdentityDisplayNameResponseObject interface {
+	VisitUpdateIdentityDisplayNameResponse(w http.ResponseWriter) error
+}
+
+type UpdateIdentityDisplayName200JSONResponse GenericMessage
+
+func (response UpdateIdentityDisplayName200JSONResponse) VisitUpdateIdentityDisplayNameResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateIdentityDisplayName400JSONResponse struct{ N400JSONResponse }
+
+func (response UpdateIdentityDisplayName400JSONResponse) VisitUpdateIdentityDisplayNameResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(400)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateIdentityDisplayName401JSONResponse struct{ N401JSONResponse }
+
+func (response UpdateIdentityDisplayName401JSONResponse) VisitUpdateIdentityDisplayNameResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(401)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateIdentityDisplayName403JSONResponse struct{ N403JSONResponse }
+
+func (response UpdateIdentityDisplayName403JSONResponse) VisitUpdateIdentityDisplayNameResponse(w http.ResponseWriter) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(403)
+
+	return json.NewEncoder(w).Encode(response)
+}
+
+type UpdateIdentityDisplayName500JSONResponse struct{ N500CreateIdentityJSONResponse }
+
+func (response UpdateIdentityDisplayName500JSONResponse) VisitUpdateIdentityDisplayNameResponse(w http.ResponseWriter) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(500)
 
@@ -5294,6 +5399,9 @@ type StrictServerInterface interface {
 	// Create Identity
 	// (POST /v1/identities)
 	CreateIdentity(ctx context.Context, request CreateIdentityRequestObject) (CreateIdentityResponseObject, error)
+	// Update Identity DisplayName field
+	// (PATCH /v1/identities/{identifier})
+	UpdateIdentityDisplayName(ctx context.Context, request UpdateIdentityDisplayNameRequestObject) (UpdateIdentityDisplayNameResponseObject, error)
 	// Identity Detail
 	// (GET /v1/identities/{identifier}/details)
 	GetIdentityDetails(ctx context.Context, request GetIdentityDetailsRequestObject) (GetIdentityDetailsResponseObject, error)
@@ -5730,6 +5838,39 @@ func (sh *strictHandler) CreateIdentity(w http.ResponseWriter, r *http.Request) 
 		sh.options.ResponseErrorHandlerFunc(w, r, err)
 	} else if validResponse, ok := response.(CreateIdentityResponseObject); ok {
 		if err := validResponse.VisitCreateIdentityResponse(w); err != nil {
+			sh.options.ResponseErrorHandlerFunc(w, r, err)
+		}
+	} else if response != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, fmt.Errorf("unexpected response type: %T", response))
+	}
+}
+
+// UpdateIdentityDisplayName operation middleware
+func (sh *strictHandler) UpdateIdentityDisplayName(w http.ResponseWriter, r *http.Request, identifier PathIdentifier) {
+	var request UpdateIdentityDisplayNameRequestObject
+
+	request.Identifier = identifier
+
+	var body UpdateIdentityDisplayNameJSONRequestBody
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+		return
+	}
+	request.Body = &body
+
+	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
+		return sh.ssi.UpdateIdentityDisplayName(ctx, request.(UpdateIdentityDisplayNameRequestObject))
+	}
+	for _, middleware := range sh.middlewares {
+		handler = middleware(handler, "UpdateIdentityDisplayName")
+	}
+
+	response, err := handler(r.Context(), w, r, request)
+
+	if err != nil {
+		sh.options.ResponseErrorHandlerFunc(w, r, err)
+	} else if validResponse, ok := response.(UpdateIdentityDisplayNameResponseObject); ok {
+		if err := validResponse.VisitUpdateIdentityDisplayNameResponse(w); err != nil {
 			sh.options.ResponseErrorHandlerFunc(w, r, err)
 		}
 	} else if response != nil {

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -348,7 +348,7 @@ type GetConnectionsResponse = []GetConnectionResponse
 type GetIdentitiesResponse struct {
 	AuthBJJCredentialStatus *GetIdentitiesResponseAuthBJJCredentialStatus `json:"authBJJCredentialStatus,omitempty"`
 	Blockchain              string                                        `json:"blockchain"`
-	DisplayName             string                                        `json:"displayName"`
+	DisplayName             *string                                       `json:"displayName,omitempty"`
 	Identifier              string                                        `json:"identifier"`
 	Method                  string                                        `json:"method"`
 	Network                 string                                        `json:"network"`

--- a/internal/api/identity.go
+++ b/internal/api/identity.go
@@ -66,6 +66,7 @@ func (s *Server) CreateIdentity(ctx context.Context, request CreateIdentityReque
 		Blockchain:              core.Blockchain(blockchain),
 		KeyType:                 kms.KeyType(keyType),
 		AuthBJJCredentialStatus: authBJJCredentialStatus,
+		DisplayName:             request.Body.DisplayName,
 	})
 	if err != nil {
 		if errors.Is(err, services.ErrWrongDIDMetada) {
@@ -96,7 +97,8 @@ func (s *Server) CreateIdentity(ctx context.Context, request CreateIdentityReque
 	}
 
 	return CreateIdentity201JSONResponse{
-		Identifier: &identity.Identifier,
+		Identifier:  &identity.Identifier,
+		DisplayName: identity.DisplayName,
 		State: &IdentityState{
 			BlockNumber:        identity.State.BlockNumber,
 			BlockTimestamp:     identity.State.BlockTimestamp,
@@ -114,6 +116,31 @@ func (s *Server) CreateIdentity(ctx context.Context, request CreateIdentityReque
 	}, nil
 }
 
+// UpdateIdentityDisplayName is update identity display name controller
+func (s *Server) UpdateIdentityDisplayName(ctx context.Context, request UpdateIdentityDisplayNameRequestObject) (UpdateIdentityDisplayNameResponseObject, error) {
+	userDID, err := w3c.ParseDID(request.Identifier)
+	if err != nil {
+		log.Error(ctx, "update identity display name. Parsing did", "err", err)
+		return UpdateIdentityDisplayName400JSONResponse{
+			N400JSONResponse{
+				Message: "invalid did",
+			},
+		}, err
+	}
+
+	err = s.identityService.UpdateIdentityDisplayName(ctx, *userDID, request.Body.DisplayName)
+	if err != nil {
+		log.Error(ctx, "update identity display name. updating display name", "err", err)
+		return UpdateIdentityDisplayName400JSONResponse{
+			N400JSONResponse{
+				Message: "invalid identity",
+			},
+		}, err
+	}
+
+	return UpdateIdentityDisplayName200JSONResponse{}, nil
+}
+
 // GetIdentities is the controller to get identities
 func (s *Server) GetIdentities(ctx context.Context, request GetIdentitiesRequestObject) (GetIdentitiesResponseObject, error) {
 	var err error
@@ -127,7 +154,7 @@ func (s *Server) GetIdentities(ctx context.Context, request GetIdentitiesRequest
 
 	partsLength := 4
 	for _, identity := range identities {
-		did, err := w3c.ParseDID(identity)
+		did, err := w3c.ParseDID(identity.Identifier)
 		if err != nil {
 			return GetIdentities500JSONResponse{N500JSONResponse{
 				Message: err.Error(),
@@ -145,7 +172,7 @@ func (s *Server) GetIdentities(ctx context.Context, request GetIdentitiesRequest
 			}
 		}
 
-		items := strings.Split(identity, ":")
+		items := strings.Split(identity.Identifier, ":")
 		if len(items) < partsLength {
 			return GetIdentities500JSONResponse{N500JSONResponse{
 				Message: "Invalid identity",
@@ -153,11 +180,12 @@ func (s *Server) GetIdentities(ctx context.Context, request GetIdentitiesRequest
 		}
 
 		response = append(response, GetIdentitiesResponse{
-			Identifier:              identity,
+			Identifier:              identity.Identifier,
 			Method:                  items[1],
 			Blockchain:              items[2],
 			Network:                 items[3],
 			AuthBJJCredentialStatus: authBjjCredStatus,
+			DisplayName:             identity.DisplayName,
 		})
 	}
 

--- a/internal/api/identity_test.go
+++ b/internal/api/identity_test.go
@@ -3,9 +3,11 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	core "github.com/iden3/go-iden3-core/v2"
 	"github.com/stretchr/testify/assert"
@@ -91,6 +93,7 @@ func TestServer_CreateIdentity(t *testing.T) {
 					Network                 string                                                   `json:"network"`
 					Type                    CreateIdentityRequestDidMetadataType                     `json:"type"`
 				}{Blockchain: blockchain, Method: method, Network: network, Type: BJJ},
+				DisplayName: common.ToPointer("my display name"),
 			},
 			expected: expected{
 				httpCode: 201,
@@ -263,6 +266,72 @@ func TestServer_GetIdentities(t *testing.T) {
 				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 				assert.Equal(t, tc.expected.httpCode, rr.Code)
 				assert.True(t, len(response) >= 2)
+			}
+		})
+	}
+}
+
+func TestServer_UpdateDisplayName(t *testing.T) {
+	server := newTestServer(t, nil)
+	handler := getHandler(context.Background(), server)
+
+	identity := &domain.Identity{Identifier: "did:polygonid:polygon:amoy:2qQ8S2VKdQv7xYgzCn7KW2xgzUWrTRQjoZDYavJHBq"}
+	fixture := tests.NewFixture(storage)
+	fixture.CreateIdentity(t, identity)
+
+	state := domain.IdentityState{
+		Identifier: identity.Identifier,
+		State:      common.ToPointer("state"),
+		Status:     domain.StatusCreated,
+		ModifiedAt: time.Now(),
+		CreatedAt:  time.Now(),
+	}
+	fixture.CreateIdentityStatus(t, state)
+
+	type expected struct {
+		httpCode    int
+		displayName *string
+	}
+	type testConfig struct {
+		name     string
+		auth     func() (string, string)
+		expected expected
+	}
+
+	for _, tc := range []testConfig{
+		{
+			name: "No auth header",
+			auth: authWrong,
+			expected: expected{
+				httpCode:    http.StatusUnauthorized,
+				displayName: common.ToPointer("new display name"),
+			},
+		},
+		{
+			name: "should update display name",
+			auth: authOk,
+			expected: expected{
+				httpCode:    200,
+				displayName: common.ToPointer("new display name"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			body := UpdateIdentityDisplayNameJSONBody{
+				DisplayName: *tc.expected.displayName,
+			}
+
+			url := fmt.Sprintf("/v1/identities/%s", identity.Identifier)
+			req, err := http.NewRequest("PATCH", url, tests.JSONBody(t, body))
+			req.SetBasicAuth(tc.auth())
+			require.NoError(t, err)
+			handler.ServeHTTP(rr, req)
+
+			require.Equal(t, tc.expected.httpCode, rr.Code)
+			if tc.expected.httpCode == http.StatusOK {
+				var response UpdateIdentityDisplayName200JSONResponse
+				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
 			}
 		})
 	}

--- a/internal/api/networks.go
+++ b/internal/api/networks.go
@@ -1,0 +1,17 @@
+package api
+
+import "context"
+
+// GetSupportedNetworks is the controller to get supported networks
+func (s *Server) GetSupportedNetworks(ctx context.Context, request GetSupportedNetworksRequestObject) (GetSupportedNetworksResponseObject, error) {
+	supportedNetworks := s.networkResolver.GetSupportedNetworks()
+
+	var supportedNetworksResponse []SupportedNetworks
+	for _, sn := range supportedNetworks {
+		supportedNetworksResponse = append(supportedNetworksResponse, SupportedNetworks{
+			Blockchain: sn.Blockchain,
+			Networks:   sn.Networks,
+		})
+	}
+	return GetSupportedNetworks200JSONResponse(supportedNetworksResponse), nil
+}

--- a/internal/api/networks_test.go
+++ b/internal/api/networks_test.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestServer_GetSupportedNetworks(t *testing.T) {
+	server := newTestServer(t, nil)
+	handler := getHandler(context.Background(), server)
+
+	type expected struct {
+		httpCode int
+	}
+	type testConfig struct {
+		name     string
+		auth     func() (string, string)
+		expected expected
+	}
+
+	for _, tc := range []testConfig{
+		{
+			name: "No auth header",
+			auth: authWrong,
+			expected: expected{
+				httpCode: http.StatusUnauthorized,
+			},
+		},
+		{
+			name: "should return supported networks",
+			auth: authOk,
+			expected: expected{
+				httpCode: 200,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+
+			req, err := http.NewRequest("GET", "/v1/supported-networks", nil)
+			req.SetBasicAuth(tc.auth())
+			require.NoError(t, err)
+			handler.ServeHTTP(rr, req)
+
+			require.Equal(t, tc.expected.httpCode, rr.Code)
+			if tc.expected.httpCode == http.StatusOK {
+				var response GetSupportedNetworks200JSONResponse
+				assert.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+				assert.Equal(t, 1, len(response))
+				assert.Equal(t, "polygon", response[0].Blockchain)
+				assert.Equal(t, "amoy", response[0].Networks[0])
+			}
+		})
+	}
+}

--- a/internal/core/domain/identity.go
+++ b/internal/core/domain/identity.go
@@ -25,12 +25,18 @@ var ErrInvalidIdentifier = errors.New("invalid identifier")
 type Identity struct {
 	Identifier                    string
 	State                         IdentityState
+	DisplayName                   *string                       `json:"displayName"`
 	Relay                         string                        `json:"relay"`
 	Immutable                     bool                          `json:"immutable"`
 	KeyType                       string                        `json:"keyType"`
 	Address                       *string                       `json:"address"`
 	Balance                       *big.Int                      `json:"balance"`
 	AuthCoreClaimRevocationStatus AuthCoreClaimRevocationStatus `json:"authCoreClaimRevocationStatus"`
+}
+
+type IdentityDisplayName struct {
+	Identifier  string `json:"identifier"`
+	DisplayName string `json:"displayName"`
 }
 
 // NewIdentityFromIdentifier default identity model from identity and root state

--- a/internal/core/domain/identity.go
+++ b/internal/core/domain/identity.go
@@ -34,6 +34,7 @@ type Identity struct {
 	AuthCoreClaimRevocationStatus AuthCoreClaimRevocationStatus `json:"authCoreClaimRevocationStatus"`
 }
 
+// IdentityDisplayName struct
 type IdentityDisplayName struct {
 	Identifier  string `json:"identifier"`
 	DisplayName string `json:"displayName"`

--- a/internal/core/domain/identity.go
+++ b/internal/core/domain/identity.go
@@ -36,8 +36,8 @@ type Identity struct {
 
 // IdentityDisplayName struct
 type IdentityDisplayName struct {
-	Identifier  string `json:"identifier"`
-	DisplayName string `json:"displayName"`
+	Identifier  string  `json:"identifier"`
+	DisplayName *string `json:"displayName"`
 }
 
 // NewIdentityFromIdentifier default identity model from identity and root state

--- a/internal/core/ports/identity_repository.go
+++ b/internal/core/ports/identity_repository.go
@@ -13,8 +13,9 @@ import (
 type IndentityRepository interface {
 	Save(ctx context.Context, conn db.Querier, identity *domain.Identity) error
 	GetByID(ctx context.Context, conn db.Querier, identifier w3c.DID) (*domain.Identity, error)
-	Get(ctx context.Context, conn db.Querier) (identities []string, err error)
+	Get(ctx context.Context, conn db.Querier) (identities []domain.IdentityDisplayName, err error)
 	GetUnprocessedIssuersIDs(ctx context.Context, conn db.Querier) (issuersIDs []*w3c.DID, err error)
 	HasUnprocessedStatesByID(ctx context.Context, conn db.Querier, identifier *w3c.DID) (bool, error)
 	HasUnprocessedAndFailedStatesByID(ctx context.Context, conn db.Querier, identifier *w3c.DID) (bool, error)
+	UpdateDisplayName(ctx context.Context, conn db.Querier, identity *domain.Identity) error
 }

--- a/internal/core/ports/identity_service.go
+++ b/internal/core/ports/identity_service.go
@@ -20,6 +20,7 @@ type DIDCreationOptions struct {
 	Network                 core.NetworkID                  `json:"network"`
 	KeyType                 kms.KeyType                     `json:"keyType"`
 	AuthBJJCredentialStatus verifiable.CredentialStatusType `json:"authBJJCredentialStatus,omitempty"`
+	DisplayName             *string                         `json:"displayName,omitempty"`
 }
 
 // CreateAuthenticationQRCodeResponse represents the response of the CreateAuthenticationQRCode method
@@ -34,7 +35,7 @@ type IdentityService interface {
 	GetByDID(ctx context.Context, identifier w3c.DID) (*domain.Identity, error)
 	Create(ctx context.Context, hostURL string, didOptions *DIDCreationOptions) (*domain.Identity, error)
 	SignClaimEntry(ctx context.Context, authClaim *domain.Claim, claimEntry *core.Claim) (*verifiable.BJJSignatureProof2021, error)
-	Get(ctx context.Context) (identities []string, err error)
+	Get(ctx context.Context) (identities []domain.IdentityDisplayName, err error)
 	UpdateState(ctx context.Context, did w3c.DID) (*domain.IdentityState, error)
 	Exists(ctx context.Context, identifier w3c.DID) (bool, error)
 	GetLatestStateByID(ctx context.Context, identifier w3c.DID) (*domain.IdentityState, error)
@@ -50,4 +51,5 @@ type IdentityService interface {
 	Authenticate(ctx context.Context, message string, sessionID uuid.UUID, serverURL string) (*protocol.AuthorizationResponseMessage, error)
 	GetFailedState(ctx context.Context, identifier w3c.DID) (*domain.IdentityState, error)
 	PublishGenesisStateToRHS(ctx context.Context, did *w3c.DID) error
+	UpdateIdentityDisplayName(ctx context.Context, did w3c.DID, displayName string) error
 }

--- a/internal/db/schema/migrations/202408091258180_add_display_name_to_identities_table.sql
+++ b/internal/db/schema/migrations/202408091258180_add_display_name_to_identities_table.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE identities
+    ADD COLUMN display_name text NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE identities
+    DROP COLUMN display_name;
+-- +goose StatementEnd

--- a/internal/db/tests/fixture.go
+++ b/internal/db/tests/fixture.go
@@ -13,21 +13,23 @@ import (
 
 // Fixture - Handle testing fixture configuration
 type Fixture struct {
-	storage               *db.Storage
-	identityRepository    ports.IndentityRepository
-	claimRepository       ports.ClaimsRepository
-	connectionsRepository ports.ConnectionsRepository
-	schemaRepository      ports.SchemaRepository
+	storage                 *db.Storage
+	identityRepository      ports.IndentityRepository
+	claimRepository         ports.ClaimsRepository
+	connectionsRepository   ports.ConnectionsRepository
+	schemaRepository        ports.SchemaRepository
+	identityStateRepository ports.IdentityStateRepository
 }
 
 // NewFixture - constructor
 func NewFixture(storage *db.Storage) *Fixture {
 	return &Fixture{
-		storage:               storage,
-		identityRepository:    repositories.NewIdentity(),
-		claimRepository:       repositories.NewClaims(),
-		connectionsRepository: repositories.NewConnections(),
-		schemaRepository:      repositories.NewSchema(*storage),
+		storage:                 storage,
+		identityRepository:      repositories.NewIdentity(),
+		claimRepository:         repositories.NewClaims(),
+		connectionsRepository:   repositories.NewConnections(),
+		schemaRepository:        repositories.NewSchema(*storage),
+		identityStateRepository: repositories.NewIdentityState(),
 	}
 }
 

--- a/internal/db/tests/identity_fixture.go
+++ b/internal/db/tests/identity_fixture.go
@@ -14,3 +14,8 @@ func (f *Fixture) CreateIdentity(t *testing.T, identity *domain.Identity) {
 	t.Helper()
 	assert.NoError(t, f.identityRepository.Save(context.Background(), f.storage.Pgx, identity))
 }
+
+func (f *Fixture) CreateIdentityStatus(t *testing.T, state domain.IdentityState) {
+	t.Helper()
+	assert.NoError(t, f.identityStateRepository.Save(context.Background(), f.storage.Pgx, state))
+}

--- a/internal/db/tests/identity_fixture.go
+++ b/internal/db/tests/identity_fixture.go
@@ -15,6 +15,7 @@ func (f *Fixture) CreateIdentity(t *testing.T, identity *domain.Identity) {
 	assert.NoError(t, f.identityRepository.Save(context.Background(), f.storage.Pgx, identity))
 }
 
+// CreateIdentityStatus creates a new state for an identity
 func (f *Fixture) CreateIdentityStatus(t *testing.T, state domain.IdentityState) {
 	t.Helper()
 	assert.NoError(t, f.identityStateRepository.Save(context.Background(), f.storage.Pgx, state))

--- a/internal/repositories/identity.go
+++ b/internal/repositories/identity.go
@@ -20,7 +20,13 @@ func NewIdentity() ports.IndentityRepository {
 
 // Save - Create new identity
 func (i *identity) Save(ctx context.Context, conn db.Querier, identity *domain.Identity) error {
-	_, err := conn.Exec(ctx, `INSERT INTO identities (identifier, address, keyType) VALUES ($1, $2, $3)`, identity.Identifier, identity.Address, identity.KeyType)
+	_, err := conn.Exec(ctx, `INSERT INTO identities (identifier, address, keyType, display_name) VALUES ($1, $2, $3, $4)`, identity.Identifier, identity.Address, identity.KeyType, identity.DisplayName)
+	return err
+}
+
+// UpdateDisplayName - Update identity displayName field
+func (i *identity) UpdateDisplayName(ctx context.Context, conn db.Querier, identity *domain.Identity) error {
+	_, err := conn.Exec(ctx, `UPDATE identities SET display_name = $1 where identifier = $2`, identity.DisplayName, identity.Identifier)
 	return err
 }
 
@@ -74,8 +80,8 @@ func (i *identity) GetByID(ctx context.Context, conn db.Querier, identifier w3c.
 	return &identity, err
 }
 
-func (i *identity) Get(ctx context.Context, conn db.Querier) (identities []string, err error) {
-	rows, err := conn.Query(ctx, `SELECT identifier FROM identities`)
+func (i *identity) Get(ctx context.Context, conn db.Querier) (identities []domain.IdentityDisplayName, err error) {
+	rows, err := conn.Query(ctx, `SELECT identifier, display_name FROM identities`)
 	if err != nil {
 		return nil, err
 	}
@@ -83,12 +89,12 @@ func (i *identity) Get(ctx context.Context, conn db.Querier) (identities []strin
 	defer rows.Close()
 
 	for rows.Next() {
-		var identifier string
-		err = rows.Scan(&identifier)
+		var identityDisplayName domain.IdentityDisplayName
+		err = rows.Scan(&identityDisplayName.Identifier, &identityDisplayName.DisplayName)
 		if err != nil {
 			return nil, err
 		}
-		identities = append(identities, identifier)
+		identities = append(identities, identityDisplayName)
 	}
 
 	return identities, err


### PR DESCRIPTION
- Added `DisplayName` field to Identity table

- Updatet CreateIdentity endpoint with new field

- Added UpdateIdentityDisplayName endpoint with possibility to change new field

- Added new endpoint which returns supported (registered) blockchains/networks