### PR TITLE
fix: Rename proof type SparseMerkleTreeProof to Iden3SparseMerkleTree in all API

### DIFF
--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -96,7 +96,7 @@ func getLinkResponse(link domain.Link) Link {
 func getLinkProofs(link domain.Link) []string {
 	proofs := make([]string, 0)
 	if link.CredentialMTPProof {
-		proofs = append(proofs, string(verifiable.SparseMerkleTreeProof))
+		proofs = append(proofs, string(verifiable.Iden3SparseMerkleTreeProofType))
 	}
 
 	if link.CredentialSignatureProof {


### PR DESCRIPTION
…Proof in all API