### PR TITLE
fix: Do not expect sessionID in authQRCode response

### DIFF
--- a/ui/src/adapters/api/credentials.ts
+++ b/ui/src/adapters/api/credentials.ts
@@ -599,7 +599,6 @@ export type AuthQRCode = {
   deepLink: string;
   linkDetail: { proofTypes: ProofType[]; schemaType: string };
   qrCodeRaw: string;
-  sessionID: string;
 };
 
 const authQRCodeParser = getStrictParser<AuthQRCodeInput, AuthQRCode>()(
@@ -607,7 +606,6 @@ const authQRCodeParser = getStrictParser<AuthQRCodeInput, AuthQRCode>()(
     deepLink: z.string(),
     linkDetail: z.object({ proofTypes: proofTypeParser, schemaType: z.string() }),
     qrCodeRaw: z.string(),
-    sessionID: z.string(),
   })
 );
 


### PR DESCRIPTION
SessionID is not needed any more when creating a QR Link. This is a hotfix to sync with API changes.