### PR TITLE
Fix libx11 version

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 RUN apk add --update nodejs npm
 RUN apk add --update apache2-utils
 RUN apk add --update libwebp=1.3.2-r0
-RUN apk add --update libx11=1.8.7-r0
+RUN apk add --update libx11=1.8.9-r1
 RUN apk add --update openssl>3.1.4-r1
 COPY package.json package-lock.json ./
 


### PR DESCRIPTION
This updates the libx11 pinned version:
libx11-1.8.7-r0 -> libx11-1.8.9-r1
### issue:
When I try to install the ui locally the pinned version for libx11 (1.8.7-r0) is not available in the Alpine package repositories that the Docker environment is accessing. Instead, the available version is libx11-1.8.9-r1. 

```bash
...
 => ERROR [ui  6/10] RUN apk add --update libx11=1.8.7-r0                                                                                                                                                            0.9s
------                                                                                                                                                                                                                    
 > [ui  6/10] RUN apk add --update libx11=1.8.7-r0:                                                                                                                                                                       
0.179 fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/main/x86_64/APKINDEX.tar.gz                                                                                                                                       
0.358 fetch https://dl-cdn.alpinelinux.org/alpine/v3.20/community/x86_64/APKINDEX.tar.gz                                                                                                                                  
0.755 ERROR: unable to select packages:                                                                                                                                                                                   
0.756   libx11-1.8.9-r1:                                                                                                                                                                                                  
0.756     breaks: world[libx11=1.8.7-r0]
0.756     satisfies: libxpm-3.5.17-r0[so:libX11.so.6]
0.756                libxext-1.3.6-r2[so:libX11.so.6]
0.756                libxt-1.3.0-r5[so:libX11.so.6]

```