### PR TITLE
feat: payment requests status

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -2900,6 +2900,8 @@ components:
         - paymentOptionID
         - payments
         - createdAt
+        - modifiedAt
+        - status
       properties:
         id:
           type: string
@@ -2918,6 +2920,14 @@ components:
         createdAt:
           type: string
           format: date-time
+        modifiedAt:
+          type: string
+          format: date-time
+        status:
+          type: string
+          enum: [ not-verified, success, failed, pending, canceled ]
+        paidNonce:
+          type: string
 
     PaymentRequestInfo:
       type: object

--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -72,6 +72,15 @@ const (
 	CreateKeyRequestKeyTypeSecp256k1  CreateKeyRequestKeyType = "secp256k1"
 )
 
+// Defines values for CreatePaymentRequestResponseStatus.
+const (
+	CreatePaymentRequestResponseStatusCanceled    CreatePaymentRequestResponseStatus = "canceled"
+	CreatePaymentRequestResponseStatusFailed      CreatePaymentRequestResponseStatus = "failed"
+	CreatePaymentRequestResponseStatusNotVerified CreatePaymentRequestResponseStatus = "not-verified"
+	CreatePaymentRequestResponseStatusPending     CreatePaymentRequestResponseStatus = "pending"
+	CreatePaymentRequestResponseStatusSuccess     CreatePaymentRequestResponseStatus = "success"
+)
+
 // Defines values for DisplayMethodType.
 const (
 	Iden3BasicDisplayMethodV1 DisplayMethodType = "Iden3BasicDisplayMethodV1"
@@ -119,10 +128,10 @@ const (
 
 // Defines values for StateTransactionStatus.
 const (
-	StateTransactionStatusCreated   StateTransactionStatus = "created"
-	StateTransactionStatusFailed    StateTransactionStatus = "failed"
-	StateTransactionStatusPending   StateTransactionStatus = "pending"
-	StateTransactionStatusPublished StateTransactionStatus = "published"
+	Created   StateTransactionStatus = "created"
+	Failed    StateTransactionStatus = "failed"
+	Pending   StateTransactionStatus = "pending"
+	Published StateTransactionStatus = "published"
 )
 
 // Defines values for GetConnectionsParamsSort.
@@ -364,13 +373,19 @@ type CreatePaymentRequest struct {
 
 // CreatePaymentRequestResponse defines model for CreatePaymentRequestResponse.
 type CreatePaymentRequestResponse struct {
-	CreatedAt       time.Time            `json:"createdAt"`
-	Id              openapi_types.UUID   `json:"id"`
-	IssuerDID       string               `json:"issuerDID"`
-	PaymentOptionID openapi_types.UUID   `json:"paymentOptionID"`
-	Payments        []PaymentRequestInfo `json:"payments"`
-	UserDID         string               `json:"userDID"`
+	CreatedAt       time.Time                          `json:"createdAt"`
+	Id              openapi_types.UUID                 `json:"id"`
+	IssuerDID       string                             `json:"issuerDID"`
+	ModifiedAt      time.Time                          `json:"modifiedAt"`
+	PaidNonce       *string                            `json:"paidNonce,omitempty"`
+	PaymentOptionID openapi_types.UUID                 `json:"paymentOptionID"`
+	Payments        []PaymentRequestInfo               `json:"payments"`
+	Status          CreatePaymentRequestResponseStatus `json:"status"`
+	UserDID         string                             `json:"userDID"`
 }
+
+// CreatePaymentRequestResponseStatus defines model for CreatePaymentRequestResponse.Status.
+type CreatePaymentRequestResponseStatus string
 
 // Credential defines model for Credential.
 type Credential struct {

--- a/internal/api/payment.go
+++ b/internal/api/payment.go
@@ -139,7 +139,7 @@ func (s *Server) CreatePaymentRequest(ctx context.Context, request CreatePayment
 		log.Error(ctx, "creating payment request", "err", err)
 		return CreatePaymentRequest400JSONResponse{N400JSONResponse{Message: fmt.Sprintf("can't create payment-request: %s", err)}}, nil
 	}
-	return CreatePaymentRequest201JSONResponse(toCreatePaymentRequestResponse(payReq)), nil
+	return CreatePaymentRequest201JSONResponse(toCreatePaymentRequestResponse(ctx, payReq)), nil
 }
 
 // GetPaymentRequests is the controller to get all payment requests for an issuer
@@ -153,7 +153,7 @@ func (s *Server) GetPaymentRequests(ctx context.Context, request GetPaymentReque
 	if err != nil {
 		return GetPaymentRequests500JSONResponse{N500JSONResponse{Message: fmt.Sprintf("can't get payment-requests: %s", err)}}, nil
 	}
-	return GetPaymentRequests200JSONResponse(toGetPaymentRequestsResponse(paymentRequests)), nil
+	return GetPaymentRequests200JSONResponse(toGetPaymentRequestsResponse(ctx, paymentRequests)), nil
 }
 
 // GetPaymentRequest is the controller to get payment request by ID
@@ -167,7 +167,7 @@ func (s *Server) GetPaymentRequest(ctx context.Context, request GetPaymentReques
 	if err != nil {
 		return GetPaymentRequest500JSONResponse{N500JSONResponse{Message: fmt.Sprintf("can't get payment-request: %s", err)}}, nil
 	}
-	return GetPaymentRequest200JSONResponse(toCreatePaymentRequestResponse(paymentRequest)), nil
+	return GetPaymentRequest200JSONResponse(toCreatePaymentRequestResponse(ctx, paymentRequest)), nil
 }
 
 // DeletePaymentRequest is the controller to delete payment request

--- a/internal/api/responses.go
+++ b/internal/api/responses.go
@@ -335,15 +335,15 @@ func toPaymentOptionConfig(config domain.PaymentOptionConfig) PaymentOptionConfi
 	return cfg
 }
 
-func toGetPaymentRequestsResponse(payReq []domain.PaymentRequest) GetPaymentRequestsResponse {
+func toGetPaymentRequestsResponse(ctx context.Context, payReq []domain.PaymentRequest) GetPaymentRequestsResponse {
 	res := make([]CreatePaymentRequestResponse, len(payReq))
 	for i, pay := range payReq {
-		res[i] = toCreatePaymentRequestResponse(&pay)
+		res[i] = toCreatePaymentRequestResponse(ctx, &pay)
 	}
 	return res
 }
 
-func toCreatePaymentRequestResponse(payReq *domain.PaymentRequest) CreatePaymentRequestResponse {
+func toCreatePaymentRequestResponse(ctx context.Context, payReq *domain.PaymentRequest) CreatePaymentRequestResponse {
 	creds := make([]struct {
 		Context string `json:"context"`
 		Type    string `json:"type"`
@@ -367,7 +367,7 @@ func toCreatePaymentRequestResponse(payReq *domain.PaymentRequest) CreatePayment
 	}
 	status, err := toCreatePaymentRequestResponseStatus(payReq.Status)
 	if err != nil {
-		log.Warn(context.Background(), "unknown payment status type in payment-request", "status", payReq.Status)
+		log.Warn(ctx, "unknown payment status type in payment-request", "status", payReq.Status)
 	}
 	var paidNonce *string
 	if payReq.PaidNonce != nil {

--- a/internal/core/domain/payment.go
+++ b/internal/core/domain/payment.go
@@ -22,7 +22,26 @@ type PaymentRequest struct {
 	PaymentOptionID uuid.UUID
 	Payments        []PaymentRequestItem
 	CreatedAt       time.Time
+	ModifietAt      time.Time
+	Status          PaymentRequestStatus
+	PaidNonce       *big.Int
 }
+
+// PaymentRequestStatus represents the status of a payment request stored in the repository
+type PaymentRequestStatus string
+
+const (
+	// PaymentRequestStatusCanceled - Payment is cancelled
+	PaymentRequestStatusCanceled PaymentRequestStatus = "canceled"
+	// PaymentRequestStatusFailed - Payment is failed
+	PaymentRequestStatusFailed PaymentRequestStatus = "failed"
+	// PaymentRequestStatusNotVerified - Payment not verified
+	PaymentRequestStatusNotVerified PaymentRequestStatus = "not-verified"
+	// PaymentRequestStatusPending - Payment is pending
+	PaymentRequestStatusPending PaymentRequestStatus = "pending"
+	// PaymentRequestStatusSuccess - Payment is successful
+	PaymentRequestStatusSuccess PaymentRequestStatus = "success"
+)
 
 // PaymentRequestItem represents a payment request item
 type PaymentRequestItem struct {

--- a/internal/core/ports/payments_repository.go
+++ b/internal/core/ports/payments_repository.go
@@ -21,5 +21,6 @@ type PaymentRepository interface {
 	GetPaymentRequestByID(ctx context.Context, issuerDID w3c.DID, id uuid.UUID) (*domain.PaymentRequest, error)
 	DeletePaymentRequest(ctx context.Context, issuerDID w3c.DID, id uuid.UUID) error
 	GetAllPaymentRequests(ctx context.Context, issuerDID w3c.DID) ([]domain.PaymentRequest, error)
+	UpdatePaymentRequestStatus(ctx context.Context, issuerDID w3c.DID, id uuid.UUID, status domain.PaymentRequestStatus, paidNonce *big.Int) error
 	GetPaymentRequestItem(ctx context.Context, issuerDID w3c.DID, nonce *big.Int) (*domain.PaymentRequestItem, error)
 }

--- a/internal/core/services/payment.go
+++ b/internal/core/services/payment.go
@@ -145,6 +145,7 @@ func (p *payment) CreatePaymentRequest(ctx context.Context, req *ports.CreatePay
 		return nil, fmt.Errorf("failed to get schema: %w", err)
 	}
 
+	createTime := time.Now()
 	paymentRequest := &domain.PaymentRequest{
 		ID:        uuid.New(),
 		IssuerDID: req.IssuerDID,
@@ -157,7 +158,9 @@ func (p *payment) CreatePaymentRequest(ctx context.Context, req *ports.CreatePay
 		},
 		Description:     req.Description,
 		PaymentOptionID: req.OptionID,
-		CreatedAt:       time.Now(),
+		CreatedAt:       createTime,
+		ModifietAt:      createTime,
+		Status:          domain.PaymentRequestStatusNotVerified,
 	}
 	for _, chainConfig := range option.Config.PaymentOptions {
 		setting, found := p.settings[chainConfig.PaymentOptionID]
@@ -251,12 +254,12 @@ func (p *payment) VerifyPayment(ctx context.Context, issuerDID w3c.DID, nonce *b
 		return ports.BlockchainPaymentStatusPending, fmt.Errorf("failed to get payment request: %w", err)
 	}
 
-	if userDID != nil {
-		paymentReq, err := p.paymentsStore.GetPaymentRequestByID(ctx, issuerDID, paymentReqItem.PaymentRequestID)
-		if err != nil {
-			return ports.BlockchainPaymentStatusPending, fmt.Errorf("failed to get payment request: %w", err)
-		}
+	paymentReq, err := p.paymentsStore.GetPaymentRequestByID(ctx, issuerDID, paymentReqItem.PaymentRequestID)
+	if err != nil {
+		return ports.BlockchainPaymentStatusPending, fmt.Errorf("failed to get payment request: %w", err)
+	}
 
+	if userDID != nil {
 		if userDID.String() != paymentReq.UserDID.String() {
 			return ports.BlockchainPaymentStatusFailed, fmt.Errorf("userDID %s does not match to User DID %s in payment-request", userDID, paymentReq.UserDID)
 		}
@@ -289,7 +292,37 @@ func (p *payment) VerifyPayment(ctx context.Context, issuerDID w3c.DID, nonce *b
 		log.Error(ctx, "failed to verify payment on blockchain", "err", err, "txHash", txHash, "nonce", nonce)
 		return ports.BlockchainPaymentStatusPending, err
 	}
+
+	paymentReqStatus := getPaymentRequestStatusFromBlockChainStatus(status)
+	if paymentReqStatus != paymentReq.Status && paymentReq.Status != domain.PaymentRequestStatusSuccess {
+		var paidNonce *big.Int
+		if paymentReqStatus == domain.PaymentRequestStatusSuccess {
+			paidNonce = nonce
+		}
+		err = p.paymentsStore.UpdatePaymentRequestStatus(ctx, issuerDID, paymentReq.ID, paymentReqStatus, paidNonce)
+		if err != nil {
+			log.Error(ctx, "failed to update payment-request with new status", "err", err, "txHash", txHash, "nonce", nonce)
+			return status, err
+		}
+
+	}
+
 	return status, nil
+}
+
+func getPaymentRequestStatusFromBlockChainStatus(status ports.BlockchainPaymentStatus) domain.PaymentRequestStatus {
+	switch status {
+	case ports.BlockchainPaymentStatusPending:
+		return domain.PaymentRequestStatusPending
+	case ports.BlockchainPaymentStatusSuccess:
+		return domain.PaymentRequestStatusSuccess
+	case ports.BlockchainPaymentStatusCancelled:
+		return domain.PaymentRequestStatusCanceled
+	case ports.BlockchainPaymentStatusFailed:
+		return domain.PaymentRequestStatusFailed
+	default:
+		return domain.PaymentRequestStatusNotVerified
+	}
 }
 
 func (p *payment) verifyPaymentOnBlockchain(

--- a/internal/core/services/payment.go
+++ b/internal/core/services/payment.go
@@ -301,7 +301,7 @@ func (p *payment) VerifyPayment(ctx context.Context, issuerDID w3c.DID, nonce *b
 		}
 		err = p.paymentsStore.UpdatePaymentRequestStatus(ctx, issuerDID, paymentReq.ID, paymentReqStatus, paidNonce)
 		if err != nil {
-			log.Error(ctx, "failed to update payment-request with new status", "err", err, "txHash", txHash, "nonce", nonce)
+			log.Error(ctx, "failed to update payment-request with new status", "err", err, "txHash", txHash, "nonce", nonce, "status", status)
 			return status, err
 		}
 

--- a/internal/db/schema/migrations/2025012711184901_add_status_to_payment_request.sql
+++ b/internal/db/schema/migrations/2025012711184901_add_status_to_payment_request.sql
@@ -1,0 +1,32 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE payment_requests
+    ADD COLUMN modified_at timestamptz;
+
+ALTER TABLE payment_requests
+    ADD COLUMN status TEXT;
+
+ALTER TABLE payment_requests
+    ADD COLUMN paid_nonce numeric NULL;
+
+UPDATE payment_requests set modified_at = created_at where modified_at is null;
+UPDATE payment_requests set status = 'not-verified' where status is null;
+
+ALTER TABLE payment_requests
+    ALTER COLUMN modified_at SET NOT NULL;
+
+ALTER TABLE payment_requests
+    ALTER COLUMN status SET NOT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE payment_requests
+    DROP COLUMN modified_at;
+
+ALTER TABLE payment_requests
+    DROP COLUMN status;
+
+ALTER TABLE payment_requests
+    DROP COLUMN paid_nonce;
+-- +goose StatementEnd


### PR DESCRIPTION
- added `modifiet_at`, `status`, `paid_nonce` to `payment_requests` table
- update these fields on payment verification
- if status is `success`, than `paid_nonce` is not empty