### PR TITLE
Fix/eth resolver constructor

### DIFF
--- a/internal/network/resolver.go
+++ b/internal/network/resolver.go
@@ -178,10 +178,7 @@ func NewResolver(ctx context.Context, cfg config.Configuration, kms *kms.KMS, re
 			}
 			supportedContracts[resolverPrefixKey] = stateContract
 
-			stateResolvers[resolverPrefixKey] = state.ETHResolver{
-				RPCUrl:          networkSettings.NetworkURL,
-				ContractAddress: common.HexToAddress(networkSettings.ContractAddress),
-			}
+			stateResolvers[resolverPrefixKey] = state.NewETHResolver(networkSettings.NetworkURL, networkSettings.ContractAddress)
 		}
 		supportedNetworks = append(supportedNetworks, supportedNetwork)
 


### PR DESCRIPTION
ETHResolver must be created using NewETHResolverWithOpts or NewETHResolver. Direct struct creation (e.g. ETHResolver{}) will result in uninitialized caches and undefined behavior.