### PR TITLE
Tag created resources for permission filters

### DIFF
--- a/internal/kms/aws_kms_eth_key_provider.go
+++ b/internal/kms/aws_kms_eth_key_provider.go
@@ -78,6 +78,12 @@ func (awsKeyProv *awsKmsEthKeyProvider) New(identity *w3c.DID) (KeyID, error) {
 		KeyUsage:    types.KeyUsageTypeSignVerify,
 		Origin:      types.OriginTypeAwsKms,
 		Description: aws.String("Key from issuer node"),
+		Tags: []types.Tag{
+			{
+				Key:   aws.String("source"),
+				Value: aws.String("polygon-issuer-node"),
+			}
+		},
 	}
 
 	keyArn, err := awsKeyProv.kmsClient.CreateKey(ctx, input)

--- a/internal/kms/aws_secret_storage_provider.go
+++ b/internal/kms/aws_secret_storage_provider.go
@@ -91,6 +91,10 @@ func (a *awsSecretStorageProvider) SaveKeyMaterial(ctx context.Context, keyMater
 				Key:   aws.String("did"),
 				Value: aws.String(keyTypesParts[0]),
 			},
+			{
+				Key:   aws.String("source"),
+				Value: aws.String("polygon-issuer-node"),
+			}
 		},
 	}
 	_, err = a.secretManager.CreateSecret(ctx, input)

--- a/internal/kms/aws_secret_storage_provider.go
+++ b/internal/kms/aws_secret_storage_provider.go
@@ -120,7 +120,7 @@ func (a *awsSecretStorageProvider) searchByIdentity(ctx context.Context, identit
 
 	keyIDs := make([]KeyID, 0)
 	for _, secret := range result.SecretList {
-		if secret.Tags == nil || len(secret.Tags) != 2 {
+		if secret.Tags == nil {
 			continue
 		}
 		if aws.ToString(secret.Tags[0].Value) != keyTypeToRead {


### PR DESCRIPTION
Current configuration leads to too wide open permissions in AWS like:
```
  policy = jsonencode({
    Version = "2012-10-17",
    Statement = [
      {
        Effect = "Allow",
        Action = [
          # https://github.com/0xPolygonID/issuer-node/blob/main/go.mod#L7
          "kms:Decrypt",
          "kms:Encrypt",
          "kms:GenerateDataKey"
        ],
        Resource = "*"
      },
      {
        Effect = "Allow",
        Action = [
          # https://github.com/0xPolygonID/issuer-node/blob/main/go.mod#L7
          "secretsmanager:GetSecretValue",
          "secretsmanager:DescribeSecret",
          "secretsmanager:CreateSecret",
          "secretsmanager:PutSecretValue",
          "secretsmanager:DeleteSecret",
          "secretsmanager:TagResource",
          "secretsmanager:ListSecrets"
        ],
        # https://github.com/0xPolygonID/issuer-node/blob/main/internal/kms/aws_secret_storage_provider.go#L82
        Resource = "*"
      }
    ]
  })
```

if you add a tag, it allows to create more restrictive permissions:
```
Condition = {
  StringEquals = {
    "aws:RequestTag/source" = "polygon-issuer-node"
  }
}
```